### PR TITLE
Rename this project from PoPS to PoPS Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,5 @@ html
 .Rproj.user
 .Rhistory
 PoPS.Rproj
+pops-core.Rproj
 .DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,14 @@ All notable changes to this project should be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
+## 2020-08-21
+
+- The C++ library project renamed from PoPS to PoPS Core.
+
 ## 2020-08-12
+
+### Fixed
+
 - Exposed class now being removed with treatments
   * Added exposed class treatments to model class
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Works with X as minimum and tested through Y (X...Y)
 cmake_minimum_required(VERSION 3.11...3.13)
 
-project(PoPS
+project(pops-core
     VERSION 0.9
-    DESCRIPTION "PoPS (Pest or Pathogen Spread) Model C++ library"
+    DESCRIPTION "PoPS (Pest or Pathogen Spread) Model Core C++ library"
     LANGUAGES CXX)
 
 # Only do these if this is the main project (and not as add_subdirectory)

--- a/Doxyfile
+++ b/Doxyfile
@@ -32,7 +32,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "PoPS"
+PROJECT_NAME           = "PoPS Core"
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version
@@ -44,7 +44,7 @@ PROJECT_NUMBER         =
 # for a project that appears at the top of each page and should give viewer a
 # quick idea about the purpose of the project. Keep the description short.
 
-PROJECT_BRIEF          = "Pest or Pathogen Spread Simulation"
+PROJECT_BRIEF          = "PoPS (Pest or Pathogen Spread) Model Core C++ library"
 
 # With the PROJECT_LOGO tag one can specify a logo or an icon that is included
 # in the documentation. The maximum height of the logo should not exceed 55

--- a/README.md
+++ b/README.md
@@ -1,12 +1,23 @@
-# PoPS (Pest or Pathogen Spread) Model
+# PoPS Core - Pest or Pathogen Spread Model Core
 
-[![Build Status](https://travis-ci.org/ncsu-landscape-dynamics/PoPS.svg?branch=master)](https://travis-ci.org/ncsu-landscape-dynamics/PoPS)
+[![Build Status](https://travis-ci.org/ncsu-landscape-dynamics/pops-core.svg?branch=master)](https://travis-ci.org/ncsu-landscape-dynamics/pops-core)
 
-PoPS library
+PoPS Core is the core C++ library for the PoPS Model.
 
-PoPS (Pest or Pathogen Spread) is a C++ library for a stochastic spread model of pests and pathogens in forest and agricultural landscapes. It has been generalized and new features added but was originally developed for *Phytophthora ramorum* and the original version of the model was based on this reference paper: Ross K. Meentemeyer, Nik J. Cunniffe, Alex R. Cook, Joao A. N. Filipe, Richard D. Hunter, David M. Rizzo, and Christopher A. Gilligan 2011. Epidemiological modeling of invasion in heterogeneous landscapes: spread of sudden oak death in California (1990–2030). *Ecosphere* 2:art17. [http://dx.doi.org/10.1890/ES10-00192.1] (http://www.esajournals.org/doi/abs/10.1890/ES10-00192.1) 
+PoPS (Pest or Pathogen Spread) is a stochastic spread model of pests
+and pathogens in forest and agricultural landscapes.
+It is used for various pest, pathogens, and hosts.
+It was originally developed for *Phytophthora ramorum* and the original
+version of the model was written in R, later with Rcpp,
+and was based on this reference paper:
 
-PoPS is a header-only C++ library. It is using templates to be universal and it makes use of C++11 features, so C++11 is the minimal
+Ross K. Meentemeyer, Nik J. Cunniffe, Alex R. Cook, Joao A. N. Filipe, Richard D. Hunter, David M. Rizzo, and Christopher A. Gilligan 2011.
+Epidemiological modeling of invasion in heterogeneous landscapes: spread of sudden oak death in California (1990–2030).
+*Ecosphere* 2:art17. [https://doi.org/10.1890/ES10-00192.1]
+
+PoPS Core is a header-only C++ library.
+It is using templates for the main spatial data structures, i.e., rasters,
+to be universal and it makes use of C++11 features, so C++11 is the minimal
 required version.
 
 ## Contributing
@@ -27,11 +38,11 @@ Most bugs/issues will be found in the **master** branch as it is the branch bein
 
 When creating new features create a branch from **master** using the following syntax **feature/new_feature**. For example, we want to add a transportation network model for human assisted dispersal, the branch created would be named feature/transportation_network_model (or similar). New features will be merged into **master** once tested based on the priorities of our stakeholders first. Once new features are tested in R and Grass with the latest bug fixes and any other new features being included in the next major release we will merge them into **master** and create an official major release version (e.g. update from version 1.1 to version 2.0). 
 
-If you are interested in contributing to PoPS development and are not a core developer on the model, please take a look at following
+If you are interested in contributing to PoPS and are not a core developer on the model, please take a look at following
 documents to make the process as seamless as possible.
 
 1. [Contributor Code of Conduct](contributing_docs/CODE_OF_CONDUCT.md)
-1. [PoPS Style Guide](contributing_docs/STYLE_GUIDE.md)
+1. [PoPS Core Style Guide](contributing_docs/STYLE_GUIDE.md)
 1. [Contributor Guide](contributing_docs/CONTRIBUTING.md)
 
 ## C++ API
@@ -67,14 +78,11 @@ The custom date class is used to easily manage different time steps within the m
 
 ## Using the model
 
-The PoPS library can be used directly in a C++ program or through other
-programs. It is used in an experimental version of a GRASS GIS module
-called r.spread.pest.
+The PoPS Core library can be used directly in a C++ program or through other
+programs. It is used in R package called rpops and a GRASS GIS module
+called r.pops.spread.
 
 * https://github.com/ncsu-landscape-dynamics/r.pops.spread
-
-It is also used in the pops_model function in R.
-
 * https://github.com/ncsu-landscape-dynamics/rpops
 
 ## Integrating the library into your own project
@@ -88,20 +96,20 @@ Git supports inclusion of other repositories into your own code using
 a mechanism called submodules. In your repository, run:
 
 ```
-git submodule add https://github.com/ncsu-landscape-dynamics/PoPS pops
+git submodule add https://github.com/ncsu-landscape-dynamics/pops-core
 ```
 
-If you want a specific branch of the PoPS library. After adding the 
+If you want a specific branch of PoPS Core, after adding the
 PoPS submodule, run the following commands (with branch-name being
 the branch of the PoPS library you want to use):
 
 ```
-cd pops
+cd pops-core
 git checkout origin/branch-name
 ```
 
-The will create a directory called `pops` in your repository which will
-now contain all the files from this repository. You can use the two
+The will create a directory called `pops-core` in your repository which
+will now contain all the files from this repository. You can use the two
 following commands to see the changes to your repository:
 
 ```
@@ -116,14 +124,14 @@ the currently latest commit to PoPS library.
 You can now commit and push changes to your repository.
 
 When someone else clones our project, they need to run the two following
-commands to get the content of the `pops` directory:
+commands to get the content of the `pops-core` directory:
 
 ```
 git submodule init
 git submodule update
 ```
 
-Alternatively, the `pops` directory can be populated during cloning
+Alternatively, the `pops-core` directory can be populated during cloning
 when `git clone` is used with the `--recurse-submodules` parameter.
 
 If you want to update the specific PoPS commit your repository is using
@@ -173,12 +181,12 @@ your project since this a header-only library. However,
 if you are using CMake, you probably want to use the following approach.
 
 Assuming you added the directory as a submodule or a plain subdirectory
-called `PoPS` add these two following lines to your `CMakeLists.txt` file
+called `pops-core` add these two following lines to your `CMakeLists.txt` file
 (assuming you already have target called `your_target`):
 
 ```
-add_subdirectory(PoPS)
-target_link_libraries(your_target PRIVATE pops)
+add_subdirectory(pops-core)
+target_link_libraries(your_target PRIVATE pops-core)
 ```
 
 ## Testing the model in this repository using make (obsolete)

--- a/contributing_docs/CONTRIBUTING.md
+++ b/contributing_docs/CONTRIBUTING.md
@@ -1,12 +1,12 @@
-# Contributing to PoPS development from outside of core development team.
+# Contributing to PoPS Core from outside of core development team.
 
-The goal of this guide is to help you get up and contributing to PoPS and/or rPoPS as quickly as possible. The guide is divided into two main pieces:
+The goal of this guide is to help you get up and contributing to PoPS Core and/or rPoPS as quickly as possible. The guide is divided into two main pieces:
 
 1. Filing a bug report or feature request in an issue.
 1. Suggesting a change via a pull request.
 
-Please note that 'PoPS is released with a [Contributor Code of Conduct](contributing/CODE_OF_CONDUCT.md). By contributing to this project, 
-you agree to abide by its terms.
+Please note that PoPS Core and rPoPS are released with a [Contributor Code of Conduct](contributing/CODE_OF_CONDUCT.md).
+By contributing to this project, you agree to abide by its terms.
 
 ## Issues
 
@@ -30,13 +30,13 @@ example reproducible: required packages, data, code.
 
 ## Pull 
 
-To contribute a change to PoPS or rPoPS, follow these steps:
+To contribute a change to PoPS Core or rPoPS, follow these steps:
 
 1. Create a branch in git and make your changes.
 1. Push branch to github and issue pull request (PR) if new feature add to a feature/new_feature branch.
 1. Discuss the pull request.
 1. Iterate until either we accept the PR or decide that it's not
-   a good fit for PoPS.
+   a good fit for this project.
 
 Each of these steps are described in more detail below. This might feel 
 overwhelming the first time you get set up, but it gets easier with practice. 
@@ -46,7 +46,7 @@ overwhelming the first time you get set up, but it gets easier with practice.
       In parentheses, reference your github user name and this issue:
       `(@ChrisJones687, #1234)`
 * [ ] Check pull request only includes relevant changes.
-* [ ] Use the [PoPS style guide](contributing_docs/STYLE_GUIDE.md).
+* [ ] Use the [PoPS Core style guide](contributing_docs/STYLE_GUIDE.md).
 * [ ] Update documentation to reflect your changes
 * [ ] Add test (if a new feature or a bug fix that needs a new test)
 * [ ] Add minimal example if new function in R.
@@ -71,14 +71,14 @@ Pull requests will be evaluated against a seven point checklist:
     multiple changes that depend on each other, start with the first one
     and don't submit any others until the first one has been processed.
 
-1.  __Use PoPS coding style__. Please follow the
-    [PoPS style guide](contributing/STYLE_GUIDE.md). Maintaining
+1.  __Use PoPS Core coding style__. Please follow the
+    [PoPS Core style guide](contributing/STYLE_GUIDE.md). Maintaining
     a consistent style across the whole code base makes it much easier to
-    jump into the code. If you're modifying existing PoPS code that
+    jump into the code. If you're modifying existing code that
     doesn't follow the style guide, a separate pull request to fix the
     style would be greatly appreciated.
 
-1.  If you're adding new parameters or a new function to the r package, you'll also need
+1.  If you're adding new parameters or a new function to the R package, you'll also need
     to document them with [roxygen](https://github.com/klutometis/roxygen).
     Make sure to re-run `devtools::document()` on the code before submitting.
 

--- a/contributing_docs/STYLE_GUIDE.md
+++ b/contributing_docs/STYLE_GUIDE.md
@@ -1,4 +1,7 @@
-# Contributing to PoPS
+# Contributing to PoPS Core
+
+This guide applies to PoPS Core (the C++ library), but also the
+C++ parts of the rpops R package.
 
 ## Style guide
 


### PR DESCRIPTION
We use PoPS as a name for the whole project and it makes sense to have also rpops and r.pops.spread
under the name PoPS. This library is just one part of it.

However, it is the core of PoPS, so calling it PoPS Core in text and pops-core elsewhere.
Keeping pops (and PoPS) in the code because it is the PoPS interface/library in C++.
