### PR TITLE
Rename total_hosts to total_populations and document run_step

### DIFF
--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -81,7 +81,7 @@ public:
      * No treatment can be applied when movement is active because host movement does
      * not support resistant hosts.
      *
-     * *dispersers* is for intrnal use and for stracking dispersers creation.
+     * *dispersers* is for internal use and for tracking dispersers creation.
      * The input values are ignored and the output is not the current existing
      * dispersers, but only the number of dispersers generated (and subsequently
      * used) in this step. There are no dispersers in between simulation steps.

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -68,12 +68,57 @@ public:
               config.movement_stochasticity)
     {}
 
+    /**
+     * @brief Run one step of the simulation.
+     *
+     * The *total_populations* can be total number of hosts in the basic case
+     * or it can be the total size of population of all relevant species
+     * both host and non-host if dilution effect should be applied.
+     * When movement is applied, *total_populations* needs to be only the
+     * total number of hosts because movement does not support non-host
+     * individuals.
+     *
+     * No treatment can be applied when movement is active because host movement does
+     * not support resistant hosts.
+     *
+     * *dispersers* is for intrnal use and for stracking dispersers creation.
+     * The input values are ignored and the output is not the current existing
+     * dispersers, but only the number of dispersers generated (and subsequently
+     * used) in this step. There are no dispersers in between simulation steps.
+     *
+     * @param step Step number in the simulation.
+     * @param[in,out] infected Infected hosts
+     * @param[in,out] susceptible Susceptible hosts
+     * @param[in,out] total_populations All host and non-host individuals in the area
+     * @param[out] dispersers Dispersing individuals (used internally)
+     * @param exposed[in,out] Exposed hosts (if SEI model is active)
+     * @param mortality_tracker[in,out] Mortality tracker used to generate *died*
+     * @param died[out] Infected hosts which died this step based on the mortality
+     * schedule
+     * @param temperatures[in] Vector of temperatures used to evaluate lethal
+     * temperature
+     * @param weather_coefficient[in] Weather coefficient
+     * @param treatments[in,out] Treatments to be applied (also tracks use of
+     * treatments)
+     * @param resistant[in,out] Resistant hosts (host temporarily removed from
+     * susceptable hosts)
+     * @param outside_dispersers[in,out] Dispersers escaping the rasters (adds to the
+     * vector)
+     * @param spread_rate[in,out] Spread rate tracker
+     * @param quarantine[in,out] Quarantine escape tracker
+     * @param quarantine_areas[in] Quarantine areas
+     * @param movements[in] Table of host movements
+     *
+     * @note The parameters roughly correspond to Simulation::disperse()
+     * and Simulation::disperse_and_infect() functions, so these can be used
+     * for further reference.
+     */
     void run_step(
         int step,
         int weather_step,  // TODO: this should be schedule (?)
         IntegerRaster& infected,
         IntegerRaster& susceptible,
-        IntegerRaster& total_hosts,  // TODO: How it is with updating this?
+        IntegerRaster& total_populations,
         IntegerRaster& dispersers,
         std::vector<IntegerRaster>& exposed,
         std::vector<IntegerRaster>& mortality_tracker,
@@ -151,7 +196,7 @@ public:
                 exposed,
                 infected,
                 mortality_tracker[mortality_simulation_year],
-                total_hosts,
+                total_populations,
                 outside_dispersers,
                 config_.weather,
                 weather_coefficients[weather_step],
@@ -162,7 +207,7 @@ public:
                     infected,
                     susceptible,
                     mortality_tracker[mortality_simulation_year],
-                    total_hosts,
+                    total_populations,
                     step,
                     last_index,
                     movements,

--- a/include/pops/simulation.hpp
+++ b/include/pops/simulation.hpp
@@ -216,10 +216,14 @@ public:
 
     /** Moves hosts from one location to another
      *
+     * @note Note that unlike the other functions, here, *total_hosts*,
+     * i.e., number of hosts is required, not number of all hosts
+     * and non-host individuals.
+     *
      * @param infected Currently infected hosts
      * @param susceptible Currently susceptible hosts
      * @param mortality_tracker Hosts that are infected at a specific time step
-     * @param total_hosts total number of hosts
+     * @param total_hosts Total number of hosts
      * @param step the current step of the simulation
      * @param last_index the last index to not be used from movements
      * @param movements a vector of ints with row_from, col_from, row_to, col_to, and
@@ -366,6 +370,10 @@ public:
      * on the result, i.e. function returning
      * `std::make_tuple(row, column)` fulfills this requirement.
      *
+     * The *total_populations* can be total number of hosts in the basic case
+     * or it can be the total size of population of all relevant species
+     * both host and non-host if dilution effect should be applied.
+     *
      * If establishment stochasticity is disabled,
      * *establishment_probability* is used to decide whether or not
      * a disperser is established in a cell. Value 1 means that all
@@ -376,7 +384,7 @@ public:
      * @param[in,out] susceptible Susceptible hosts
      * @param[in,out] exposed_or_infected Exposed or infected hosts
      * @param[in,out] mortality_tracker Newly infected hosts (if applicable)
-     * @param[in] total_hosts All hosts in the area
+     * @param[in] total_populations All host and non-host individuals in the area
      * @param[in,out] outside_dispersers Dispersers escaping the rasters
      * @param weather Whether or not weather coefficients should be used
      * @param[in] weather_coefficient Weather coefficient for each location
@@ -393,7 +401,7 @@ public:
         IntegerRaster& susceptible,
         IntegerRaster& exposed_or_infected,
         IntegerRaster& mortality_tracker,
-        const IntegerRaster& total_hosts,
+        const IntegerRaster& total_populations,
         std::vector<std::tuple<int, int>>& outside_dispersers,
         bool weather,
         const FloatRaster& weather_coefficient,
@@ -417,7 +425,8 @@ public:
                         }
                         if (susceptible(row, col) > 0) {
                             double probability_of_establishment =
-                                (double)(susceptible(row, col)) / total_hosts(row, col);
+                                (double)(susceptible(row, col))
+                                / total_populations(row, col);
                             double establishment_tester = 1 - establishment_probability;
                             if (establishment_stochasticity_)
                                 establishment_tester = distribution_uniform(generator_);
@@ -556,7 +565,7 @@ public:
         std::vector<IntegerRaster>& exposed,
         IntegerRaster& infected,
         IntegerRaster& mortality_tracker,
-        const IntegerRaster& total_hosts,
+        const IntegerRaster& total_populations,
         std::vector<std::tuple<int, int>>& outside_dispersers,
         bool weather,
         const FloatRaster& weather_coefficient,
@@ -574,7 +583,7 @@ public:
             susceptible,
             *infected_or_exposed,
             mortality_tracker,
-            total_hosts,
+            total_populations,
             outside_dispersers,
             weather,
             weather_coefficient,


### PR DESCRIPTION
This renames total_hosts to total_populations (#91), updates documentation to emphasize the distinction,
and adds documentation to Model::run_step().
