### PR TITLE
Enable compiler warnings in CMake

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -13,6 +13,7 @@ jobs:
         os:
         - ubuntu-16.04
         - ubuntu-18.04
+        - ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,17 @@ All notable changes to this project should be documented in this file.
 
 The format is based on [Keep a Changelog](http://keepachangelog.com/).
 
-## 2020-08-24 - Version 1 preparations
+## 2020-08-27 - Version 1 preparations
 
 ### Changed
 
 - The C++ library project renamed from PoPS to PoPS Core.
 - Only the current weather coefficient is now passed to the model class.
+- Raster class uses `int` by default for indexing.
+
+### Fixed
+
+- Numerous compiler warnings fixed. Code now compiles with -Wall -Wextra.
 
 ## 2020-08-12
 

--- a/TECHNICALDEBT.md
+++ b/TECHNICALDEBT.md
@@ -42,7 +42,6 @@ optionally linked in an entry.
 ### Fix
 
 - Add return code to raster class template test.
-- Resolve the `-Wsign-compare` warnings.
 
 ## 2019-08-11 - Dispersal kernel rewrite
 
@@ -110,7 +109,6 @@ optionally linked in an entry.
 - Even after the upgrade to Raster class, there are still some legacy
   method names and integers instead of doubles (but does not influence
   computations).
-- Numerous sign-compare warnings.
 - Spelling in the code and comments.
 
 ## 2018-06-13 - Spotted Lanternfly

--- a/include/pops/date.hpp
+++ b/include/pops/date.hpp
@@ -44,6 +44,7 @@ public:
     Date(const Date& d) : year_(d.year_), month_(d.month_), day_(d.day_) {}
     Date(int y, int m, int d) : year_(y), month_(m), day_(d) {}
     Date(std::string date);
+    Date& operator=(const Date&) = default;
     inline void increased_by_days(int num_days);
     inline void increased_by_week();
     inline void increased_by_month();

--- a/include/pops/deterministic_kernel.hpp
+++ b/include/pops/deterministic_kernel.hpp
@@ -21,6 +21,7 @@
 
 #include "raster.hpp"
 #include "kernel_types.hpp"
+#include "utils.hpp"
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
@@ -199,6 +200,7 @@ public:
     template<class Generator>
     std::tuple<int, int> operator()(Generator& generator, int row, int col)
     {
+        UNUSED(generator);  // Deterministic does not need random numbers.
         if (kernel_type_ != DispersalKernelType::Cauchy
             && kernel_type_ != DispersalKernelType::Exponential) {
             throw std::invalid_argument(

--- a/include/pops/neighbor_kernel.hpp
+++ b/include/pops/neighbor_kernel.hpp
@@ -18,6 +18,7 @@
 
 #include "kernel_types.hpp"
 #include "radial_kernel.hpp"
+#include "utils.hpp"
 
 namespace pops {
 
@@ -60,6 +61,7 @@ public:
     template<typename Generator>
     std::tuple<int, int> operator()(Generator& generator, int row, int col)
     {
+        UNUSED(generator);  // Deterministic does not need random numbers.
         switch (direction_) {
         case Direction::E:
             col += 1;
@@ -96,10 +98,12 @@ public:
         return std::make_tuple(row, col);
     }
 
-    /*! Enum value is defined, so this always returns false.
+    /*! \copybrief RadialDispersalKernel::supports_kernel()
      */
     static bool supports_kernel(const DispersalKernelType type)
     {
+        if (type == DispersalKernelType::DeterministicNeighbor)
+            return true;
         return false;
     }
 };

--- a/include/pops/quarantine.hpp
+++ b/include/pops/quarantine.hpp
@@ -263,8 +263,6 @@ std::vector<DistDir> distance_direction_to_quarantine(
 {
     bool escape;
     DistDir distdir;
-    double dist;
-    QuarantineDirection dir;
     std::vector<DistDir> distances_directions;
     for (const auto& item : escape_infos) {
         std::tie(escape, distdir) = item.escape_info(step);

--- a/include/pops/raster.hpp
+++ b/include/pops/raster.hpp
@@ -88,8 +88,12 @@ for_each_zip(InputIt1 first1, InputIt1 last1, InputIt2 first2, BinaryOperation f
  * scalars using `std::common_type`, i.e. `a * b` where `a` is an
  * integral raster type and `b` is a floating raster type produce
  * a floating raster type.
+ *
+ * The Index template parameter is an signed or unsigned integer used for
+ * indexing of rows and columns. The default value is int because signed
+ * indices is the modern C++ practice and int is used in Rcpp.
  */
-template<typename Number, typename Index = unsigned>
+template<typename Number, typename Index = int>
 class Raster
 {
 protected:

--- a/include/pops/simulation.hpp
+++ b/include/pops/simulation.hpp
@@ -26,6 +26,8 @@
 #include <string>
 #include <stdexcept>
 
+#include "utils.hpp"
+
 namespace pops {
 
 /** Rotate elements in a container to the left by one
@@ -230,6 +232,8 @@ public:
      * num_hosts
      * @param movement_schedule a vector matching movements with the step at which the
      * movement from movements are applied
+     *
+     * @note Mortality and non-host individuals are not supported in movements.
      */
     unsigned movement(
         IntegerRaster& infected,
@@ -241,6 +245,7 @@ public:
         const std::vector<std::vector<int>>& movements,
         std::vector<unsigned> movement_schedule)
     {
+        UNUSED(mortality_tracker);  // Mortality is not supported by movements.
         for (unsigned i = last_index; i < movements.size(); i++) {
             auto moved = movements[i];
             unsigned move_schedule = movement_schedule[i];

--- a/include/pops/utils.hpp
+++ b/include/pops/utils.hpp
@@ -1,0 +1,35 @@
+#ifndef POPS_UTILS_HPP
+#define POPS_UTILS_HPP
+
+/*
+ * PoPS model - general utility functions (unrelated to the model)
+ *
+ * Copyright (C) 2020 by the authors.
+ *
+ * Authors: Vaclav Petras <wenzeslaus gmail com>
+ *
+ * The code contained herein is licensed under the GNU General Public
+ * License. You may obtain a copy of the GNU General Public License
+ * Version 2 or later at the following locations:
+ *
+ * http://www.opensource.org/licenses/gpl-license.html
+ * http://www.gnu.org/copyleft/gpl.html
+ */
+
+/*!
+ * Macro to mark unused variables (including paramters) and silence the warning
+ * while documenting that it is intentionally unused.
+ *
+ * It is recommended to also document why the variable is unused, but left in the code.
+ *
+ * Usage:
+ *
+ * ```
+ * UNUSED(variable_name);  // Parameter needed for backwards compatibility.
+ * ```
+ *
+ * To be replaced by `[[maybe_unused]]` once we migrate to C++17 or higher.
+ */
+#define UNUSED(expr) (void)(expr)
+
+#endif // POPS_UTILS_HPP

--- a/include/pops/utils.hpp
+++ b/include/pops/utils.hpp
@@ -32,4 +32,4 @@
  */
 #define UNUSED(expr) (void)(expr)
 
-#endif // POPS_UTILS_HPP
+#endif  // POPS_UTILS_HPP

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ function(add_pops_test NAME)
     # Enable compiler warnings
     target_compile_options(${NAME} PRIVATE
          $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-              -Wall>
+              -Wall -Wunused-parameter>
          $<$<CXX_COMPILER_ID:MSVC>:
               /W4>)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,13 @@ function(add_pops_test NAME)
     # make the PoPS library a dependency
     target_link_libraries(${NAME} pops)
 
+    # Enable compiler warnings
+    target_compile_options(${NAME} PRIVATE
+         $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
+              -Wall>
+         $<$<CXX_COMPILER_ID:MSVC>:
+              /W4>)
+
     # register a test
     add_test(NAME "${NAME}" COMMAND ${NAME})
 endfunction()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ function(add_pops_test NAME)
     # Enable compiler warnings
     target_compile_options(${NAME} PRIVATE
          $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-              -Wall -Wunused-parameter>
+              -Wall -Wextra>
          $<$<CXX_COMPILER_ID:MSVC>:
               /W4>)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ function(add_pops_test NAME)
     # Enable compiler warnings
     target_compile_options(${NAME} PRIVATE
          $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-              -Wall -Wextra>
+              -Wall -Wextra -pedantic>
          $<$<CXX_COMPILER_ID:MSVC>:
               /W4>)
 

--- a/tests/test_date.cpp
+++ b/tests/test_date.cpp
@@ -103,12 +103,14 @@ int test_from_string()
     try {
         d = Date("2015-31-01");
     }
-    catch (std::invalid_argument) {
+    catch (std::invalid_argument&) {
+        // pass
     }
     try {
         d = Date("2016-04-31");
     }
-    catch (std::invalid_argument) {
+    catch (std::invalid_argument&) {
+        // pass
     }
     if (d.year() != 2020 || d.month() != 2 || d.day() != 1) {
         num_errors++;

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -567,13 +567,13 @@ int test_model_sei_deterministic_with_treatments()
     // Apply treatment to expected results (assuming rate == 1)
     // (modifying int with double is not allowed in Raster, so we have to be explicit)
     // Remove infected
-    for (unsigned int row = 0; row < expected_infected.rows(); ++row)
-        for (unsigned int col = 0; col < expected_infected.rows(); ++col)
+    for (int row = 0; row < expected_infected.rows(); ++row)
+        for (int col = 0; col < expected_infected.rows(); ++col)
             expected_infected(row, col) *= !simple_treatment(row, col);
     // Reduced number of infected
     // (assuming 1 infection (E to I) step completed, i.e. 1 initial state + 1 step)
-    for (unsigned int row = 0; row < expected_infected.rows(); ++row)
-        for (unsigned int col = 0; col < expected_infected.rows(); ++col)
+    for (int row = 0; row < expected_infected.rows(); ++row)
+        for (int col = 0; col < expected_infected.rows(); ++col)
             if (pesticide_treatment(row, col) > 0)
                 expected_infected(row, col) =
                     2 * pesticide_treatment(row, col) * infected(row, col);

--- a/tests/test_scheduling.cpp
+++ b/tests/test_scheduling.cpp
@@ -313,7 +313,7 @@ int test_unit_enum_from_string()
         step_unit_enum_from_string("invalid_input");
         num_errors++;
     }
-    catch (std::invalid_argument) {
+    catch (std::invalid_argument&) {
         // OK
     }
     catch (...) {
@@ -339,7 +339,7 @@ int test_schedule_from_string()
         out = schedule_from_string(scheduling, "day");
         num_errors++;
     }
-    catch (std::invalid_argument) {
+    catch (std::invalid_argument&) {
         // OK
     }
 

--- a/tests/test_scheduling.cpp
+++ b/tests/test_scheduling.cpp
@@ -362,7 +362,7 @@ int test_schedule_from_string()
         out = schedule_from_string(scheduling3, "week");
         num_errors++;
     }
-    catch (std::invalid_argument) {
+    catch (std::invalid_argument&) {
         // OK
     }
     out = schedule_from_string(scheduling3, "every_n_steps", 2);

--- a/tests/test_simulation.cpp
+++ b/tests/test_simulation.cpp
@@ -237,8 +237,8 @@ int exposed_state(
 {
     int ret = 0;
     Raster<int> zeros(exposed[0].rows(), exposed[0].cols(), 0);
-    for (int i = 0; i < exposed.size(); ++i) {
-        if (i >= int(exposed.size()) - step - 2 && i < exposed.size() - 1) {
+    for (unsigned int i = 0; i < exposed.size(); ++i) {
+        if (int(i) >= int(exposed.size()) - step - 2 && i < exposed.size() - 1) {
             if (exposed[i] != expected_exposed) {
                 cout << "SEI test exposed[" << i << "] (actual, expected):\n"
                      << exposed[i] << "  !=\n"

--- a/tests/test_treatments.cpp
+++ b/tests/test_treatments.cpp
@@ -440,7 +440,7 @@ int test_treat_app_from_string()
         treatment_app_enum_from_string("invalid_input");
         num_errors++;
     }
-    catch (std::invalid_argument) {
+    catch (std::invalid_argument&) {
         // OK
     }
     catch (...) {


### PR DESCRIPTION
This fixes number of C++ warnings from GCC (and clang), namely:

* Unused variables and parameters (some removed, some fixed, some marked as unused).
* pops::Raster now uses int by default as index instead of unsigned int to match Rcpp. (Applies in test.)
* Default assignment operator needs to be defined explicitly.
* Catching exceptions in a wrong way.
