### PR TITLE
Use scaled natural kernel for overpopulation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ this repository.
 
 ### Changed
 - Model class internal attributes and functions are now protected instead of private
-  to allow derived classes access them to for greater flexibility.
+  to allow derived classes to access them for greater flexibility.
 - Model class kernels are now created and returned by protected functions.
 - Config class has now more defaults and subsequent setup now consistently fails when
   required values were not set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ this repository.
 
 ### Changed
 - Model class internal attributes and functions are now protected instead of private
-  to allow derived classes access them for greater flexibility.
+  to allow derived classes access them to for greater flexibility.
 - Model class kernels are now created and returned by protected functions.
 - Config class has now more defaults and subsequent setup now consistently fails when
   required values were not set.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ this repository.
 
 ### Added
 
-- Pest pest movement based on overpopulation (Vaclav Petras)
+- Pest movement based on overpopulation (Vaclav Petras)
   * When cell contains too many pests, pests leave and move to a different cell.
 
 ## [1.0.2] - 2020-10-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,13 @@ this repository.
 - Pest movement based on overpopulation (Vaclav Petras)
   * When cell contains too many pests, pests leave and move to a different cell.
 
+### Changed
+- Model class internal attributes and functions are now protected instead of private
+  to allow derived classes access them for greater flexibility.
+- Model class kernels are now created and returned by protected functions.
+- Config class has now more defaults and subsequent setup now consistently fails when
+  required values were not set.
+
 ## [1.0.2] - 2020-10-09
 
 - [Patch release of rpops](https://github.com/ncsu-landscape-dynamics/rpops/releases/tag/v1.0.2) (no changes in pops-core)

--- a/include/pops/config.hpp
+++ b/include/pops/config.hpp
@@ -58,13 +58,13 @@ public:
     // Kernels
     std::string natural_kernel_type;
     double natural_scale{0};
-    std::string natural_direction{""};
+    std::string natural_direction;
     double natural_kappa{0};
     bool use_anthropogenic_kernel{false};
     double percent_natural_dispersal{1};
     std::string anthro_kernel_type;
     double anthro_scale{0};
-    std::string anthro_direction{""};
+    std::string anthro_direction;
     double anthro_kappa{0};
     double shape{1.0};
     // Treatments

--- a/include/pops/config.hpp
+++ b/include/pops/config.hpp
@@ -57,15 +57,15 @@ public:
     int latency_period_steps;
     // Kernels
     std::string natural_kernel_type;
-    double natural_scale;
-    std::string natural_direction;
-    double natural_kappa;
+    double natural_scale{0};
+    std::string natural_direction{""};
+    double natural_kappa{0};
     bool use_anthropogenic_kernel{false};
-    double percent_natural_dispersal;
+    double percent_natural_dispersal{1};
     std::string anthro_kernel_type;
-    double anthro_scale;
-    std::string anthro_direction;
-    double anthro_kappa;
+    double anthro_scale{0};
+    std::string anthro_direction{""};
+    double anthro_kappa{0};
     double shape{1.0};
     // Treatments
     bool use_treatments{false};

--- a/include/pops/config.hpp
+++ b/include/pops/config.hpp
@@ -89,6 +89,7 @@ public:
     bool use_overpopulation_movements{false};
     double overpopulation_percentage{0};
     double leaving_percentage{0};
+    double leaving_scale_coefficient{1};
 
     void create_schedules()
     {

--- a/include/pops/deterministic_kernel.hpp
+++ b/include/pops/deterministic_kernel.hpp
@@ -92,6 +92,25 @@ protected:
     double north_south_resolution;
 
 public:
+    /**
+     * @brief DeterministicDispersalKernel constructor
+     *
+     * When an unsupported (invalid) kernel type is passed as *dispersal_kernel*,
+     * std::invalid_argument is thrown when the function call operator is used,
+     * i.e., it is accepted by the constructor. This is to allow for constuction
+     * of invalid, but unused kernels which are created as a part of larger kernels.
+     *
+     * The reference *dispersers* is later used to obtain the current counts of
+     * dispersers.
+     *
+     * @param dispersal_kernel Type of kernel to be used
+     * @param dispersers Reference to a dispersers raster
+     * @param dispersal_percentage Percentage used to compute the kernel size
+     * @param ew_res East-west resolution
+     * @param ns_res North-south resolution
+     * @param distance_scale Scale parameter for the kernels
+     * @param shape Shape parameter for the kernels
+     */
     DeterministicDispersalKernel(
         DispersalKernelType dispersal_kernel,
         const IntegerRaster& dispersers,

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -247,13 +247,6 @@ public:
         const std::vector<std::vector<int>> movements,
         const std::vector<std::vector<int>>& suitable_cells)
     {
-
-        DispersalKernel<IntegerRaster> dispersal_kernel(
-            build_natural_kernel(dispersers),
-            build_anthro_kernel(dispersers),
-            config_.use_anthropogenic_kernel,
-            config_.percent_natural_dispersal);
-        auto overpopulation_kernel = build_overpopulation_movement_kernel(dispersers);
         int mortality_simulation_year =
             simulation_step_to_action_step(config_.mortality_schedule(), step);
         // removal of dispersers due to lethal temperatures
@@ -276,6 +269,14 @@ public:
                 weather_coefficient,
                 config_.reproductive_rate,
                 suitable_cells);
+
+            DispersalKernel<IntegerRaster> dispersal_kernel(
+                create_natural_kernel(dispersers),
+                create_anthro_kernel(dispersers),
+                config_.use_anthropogenic_kernel,
+                config_.percent_natural_dispersal);
+            auto overpopulation_kernel =
+                create_overpopulation_movement_kernel(dispersers);
 
             simulation_.disperse_and_infect(
                 step,

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -85,7 +85,7 @@ protected:
             config_.ew_res,
             config_.ns_res,
             natural_kernel,
-            config_.natural_scale * config_.leaving_scale,
+            config_.natural_scale * config_.leaving_scale_coefficient,
             direction_from_string(config_.natural_direction),
             config_.natural_kappa,
             config_.shape);
@@ -95,7 +95,7 @@ protected:
             config_.dispersal_percentage,
             config_.ew_res,
             config_.ns_res,
-            config_.natural_scale * config_.leaving_scale,
+            config_.natural_scale * config_.leaving_scale_coefficient,
             config_.shape);
         SwitchDispersalKernel<IntegerRaster> selectable_kernel(
             natural_kernel,

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -50,15 +50,15 @@ protected:
     unsigned last_index{0};
 
     /**
-     * @brief Build natural kernel
+     * @brief Create natural kernel
      *
      * Kernel parameters are taken from the configuration.
      *
-     * @param dispersers The current dispersers (for deterministic kernel)
+     * @param dispersers The disperser raster (reference, for deterministic kernel)
      * @return Created kernel
      */
     SwitchDispersalKernel<IntegerRaster>
-    build_natural_kernel(const IntegerRaster& dispersers)
+    create_natural_kernel(const IntegerRaster& dispersers)
     {
         RadialDispersalKernel<IntegerRaster> radial_kernel(
             config_.ew_res,
@@ -87,17 +87,17 @@ protected:
     }
 
     /**
-     * @brief Build overpopulation movement kernel
+     * @brief Create overpopulation movement kernel
      *
      * Same as the natural kernel. The natural kernel parameters are used,
      * but the scale for radial and deterministic kernel is multiplied
      * by the leaving scale coefficient.
      *
-     * @param dispersers The current dispersers (for deterministic kernel)
+     * @param dispersers The disperser raster (reference, for deterministic kernel)
      * @return Created kernel
      */
     SwitchDispersalKernel<IntegerRaster>
-    build_overpopulation_movement_kernel(const IntegerRaster& dispersers)
+    create_overpopulation_movement_kernel(const IntegerRaster& dispersers)
     {
         RadialDispersalKernel<IntegerRaster> radial_kernel(
             config_.ew_res,
@@ -126,16 +126,16 @@ protected:
     }
 
     /**
-     * @brief Build anthropogenic kernel
+     * @brief Create anthropogenic kernel
      *
      * Same structure as the natural kernel, but the parameters are for anthropogenic
      * kernel when available.
      *
-     * @param dispersers The current dispersers (for deterministic kernel)
+     * @param dispersers The disperser raster (reference, for deterministic kernel)
      * @return Created kernel
      */
     SwitchDispersalKernel<IntegerRaster>
-    build_anthro_kernel(const IntegerRaster& dispersers)
+    create_anthro_kernel(const IntegerRaster& dispersers)
     {
         RadialDispersalKernel<IntegerRaster> radial_kernel(
             config_.ew_res,

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -49,6 +49,14 @@ protected:
     Simulation<IntegerRaster, FloatRaster, RasterIndex> simulation_;
     unsigned last_index{0};
 
+    /**
+     * @brief Build natural kernel
+     *
+     * Kernel parameters are taken from the configuration.
+     *
+     * @param dispersers The current dispersers (for deterministic kernel)
+     * @return Created kernel
+     */
     SwitchDispersalKernel<IntegerRaster>
     build_natural_kernel(const IntegerRaster& dispersers)
     {
@@ -78,6 +86,16 @@ protected:
         return selectable_kernel;
     }
 
+    /**
+     * @brief Build overpopulation movement kernel
+     *
+     * Same as the natural kernel. The natural kernel parameters are used,
+     * but the scale for radial and deterministic kernel is multiplied
+     * by the leaving scale coefficient.
+     *
+     * @param dispersers The current dispersers (for deterministic kernel)
+     * @return Created kernel
+     */
     SwitchDispersalKernel<IntegerRaster>
     build_overpopulation_movement_kernel(const IntegerRaster& dispersers)
     {
@@ -107,6 +125,15 @@ protected:
         return selectable_kernel;
     }
 
+    /**
+     * @brief Build anthropogenic kernel
+     *
+     * Same structure as the natural kernel, but the parameters are for anthropogenic
+     * kernel when available.
+     *
+     * @param dispersers The current dispersers (for deterministic kernel)
+     * @return Created kernel
+     */
     SwitchDispersalKernel<IntegerRaster>
     build_anthro_kernel(const IntegerRaster& dispersers)
     {

--- a/include/pops/radial_kernel.hpp
+++ b/include/pops/radial_kernel.hpp
@@ -68,9 +68,7 @@ inline Direction direction_from_string(const std::string& text)
     }
     catch (const std::out_of_range&) {
         throw std::invalid_argument(
-            "direction_from_string: Invalid"
-            " value '"
-            + text + "' provided");
+            "direction_from_string: Invalid value '" + text + "' provided");
     }
 }
 

--- a/tests/test_overpopulation_movements.cpp
+++ b/tests/test_overpopulation_movements.cpp
@@ -123,16 +123,13 @@ int test_model()
     config.model_type = "SI";
     config.natural_kernel_type = "cauchy";
     config.natural_scale = 0.1;
-    // We are not using anthropo kernel in standard disperser spread, but it is used by
-    // overpopulation movements.
-    config.use_anthropogenic_kernel = false;
-    config.anthro_kernel_type = "cauchy";
-    config.anthro_scale = 0.1;
+    config.anthro_scale = config.natural_scale;  // Unused, but we need to set it.
     config.ew_res = 30;
     config.ns_res = 30;
     config.use_overpopulation_movements = true;
     config.overpopulation_percentage = 0.5;
     config.leaving_percentage = 0.75;
+    config.leaving_scale_coefficient = 1;
     config.create_schedules();
     // More reference data
     auto leaving = infected(0, 0) * config.leaving_percentage;


### PR DESCRIPTION
Instead of (mis)using antropogenic kernel as a long distance kernel for pest overpopulation movement, scale (multiply) the scale (distance) parameter of natural kernel using a coefficient.

This adds one new config variable to modify the scale parameter of radial and deterministic kernels. It is meant as modification so it is called coefficient [of scale] (`leaving_scale_coefficient`) and it defaults to 1. "Coefficient of scale" is not ideal, but "scale of scale" would not be great either.

Additionally, this moves most of the kernel creation to separate functions. Although the duplication between the functions would be unnecessary difficult to address, the similarities between the three kernels (natural, anthro, overflow) are now more clear than in the original intermingled code and easier to keep in sync if needed. The kernels are now created only when needed since they are really not only local to the run step function, but needed only for one function call.

The new functions are protected and the existing attributes are now protected instead of private because for practical reasons, similarly to other places, we consider inheritance a case when user of a class wants to deal with internals of the object.

Finally, when config is not properly used, the new behavior is that it now consistently fails while before it was sometimes passing. In the config, we now set more defaults to ensure consistent results (that is throwing an exception when not set because the default and wrong 0 is used).