### PR TITLE
Support time_step as frequency in scheduling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ the tagged revision was already tagged before.
 - Established dispersers from a cell are now tracked. (Chris Jones)
 - Collection of general-use function for container handling for internal use.
 - Template parameter for random number generator to Model and Simulation.
+- New frequency values, every_step and time_step, can be used to schedule
+  action every step of the simulation. (Vaclav Petras)
+  * This was implemented in rpops for simple cases. The new version in Core
+    supports all unit and n combinations for the simulation step.
 
 ### Changed
 

--- a/include/pops/scheduling.hpp
+++ b/include/pops/scheduling.hpp
@@ -443,7 +443,7 @@ inline std::vector<bool> schedule_from_string(
         }
         else if (frequency == "every_n_steps" && n > 0)
             return scheduler.schedule_action_nsteps(n);
-        else if (frequency == "time_step")
+        else if (frequency == "every_step" || frequency == "time_step")
             return scheduler.schedule_action_nsteps(1);
         else
             throw std::invalid_argument("Invalid value of output frequency");

--- a/include/pops/scheduling.hpp
+++ b/include/pops/scheduling.hpp
@@ -412,7 +412,6 @@ inline std::vector<bool> schedule_from_string(
         "Output frequency and simulation step are incompatible");
     std::tie(sim_n, sim_unit) = scheduler.get_step_length();
     if (!frequency.empty()) {
-        // TODO: throw when n!=1 and it is not used?
         if (frequency == "final_step")
             return scheduler.schedule_action_end_of_simulation();
         else if (frequency == "year" || frequency == "yearly")

--- a/include/pops/scheduling.hpp
+++ b/include/pops/scheduling.hpp
@@ -412,6 +412,7 @@ inline std::vector<bool> schedule_from_string(
         "Output frequency and simulation step are incompatible");
     std::tie(sim_n, sim_unit) = scheduler.get_step_length();
     if (!frequency.empty()) {
+        // TODO: throw when n!=1 and it is not used?
         if (frequency == "final_step")
             return scheduler.schedule_action_end_of_simulation();
         else if (frequency == "year" || frequency == "yearly")
@@ -443,6 +444,8 @@ inline std::vector<bool> schedule_from_string(
         }
         else if (frequency == "every_n_steps" && n > 0)
             return scheduler.schedule_action_nsteps(n);
+        else if (frequency == "time_step")
+            return scheduler.schedule_action_nsteps(1);
         else
             throw std::invalid_argument("Invalid value of output frequency");
     }

--- a/tests/test_scheduling.cpp
+++ b/tests/test_scheduling.cpp
@@ -335,6 +335,12 @@ int test_schedule_from_string()
     out = schedule_from_string(scheduling, "every_n_steps", 2);
     if (get_number_of_scheduled_actions(out) != 2)
         num_errors++;
+    out = schedule_from_string(scheduling, "every_step");
+    if (get_number_of_scheduled_actions(out) != scheduling.get_num_steps())
+        num_errors++;
+    out = schedule_from_string(scheduling, "time_step");
+    if (get_number_of_scheduled_actions(out) != scheduling.get_num_steps())
+        num_errors++;
     try {
         out = schedule_from_string(scheduling, "day");
         num_errors++;
@@ -353,6 +359,9 @@ int test_schedule_from_string()
     out = schedule_from_string(scheduling2, "every_n_steps", 7);
     if (get_number_of_scheduled_actions(out) != 4)
         num_errors++;
+    out = schedule_from_string(scheduling2, "every_step");
+    if (get_number_of_scheduled_actions(out) != scheduling2.get_num_steps())
+        num_errors++;
     out = schedule_from_string(scheduling2, "final_step");
     if (get_number_of_scheduled_actions(out) != 1)
         num_errors++;
@@ -367,6 +376,9 @@ int test_schedule_from_string()
     }
     out = schedule_from_string(scheduling3, "every_n_steps", 2);
     if (get_number_of_scheduled_actions(out) != 1)
+        num_errors++;
+    out = schedule_from_string(scheduling3, "every_step");
+    if (get_number_of_scheduled_actions(out) != scheduling3.get_num_steps())
         num_errors++;
     out = schedule_from_string(scheduling3, "month");
     if (get_number_of_scheduled_actions(out) != 0)


### PR DESCRIPTION
This tries to remove the need for [this code](https://github.com/ncsu-landscape-dynamics/rpops/blob/62d919121d84ed33782ef58cffaf87f16e4d7ca8/src/pops.cpp#L133-L135) in rpops:

```cpp
    if (output_frequency == "time_step") {
        output_frequency = time_step;
    }
```

where time_step is 'day', 'week', 'month', ...

Any simulation unit + n combination will now work with `output_frequency == "time_step"`. This is not used with rpops if I recall correctly, but the code there seems to allow that (?).

The logic is that we know what is the step in the scheduler, so scheduling every step is just schedule every nth step with n = 1. With this in place, the rpops code does not have to get the step from parameters.

Given that we have `every_n_steps` this new option could be `every_step` not `time_step`, but perhaps it can be both since for other options, we support multiple values (`day` and `daily`). `time_step` seems to be a valid description context where n != 1, right?