### PR TITLE
CI: Remove Ubuntu 16.04

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,6 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-16.04
         - ubuntu-18.04
         - ubuntu-20.04
         cxx:


### PR DESCRIPTION
Ubuntu 16.04 environment was removed from GitHub in September.