### PR TITLE
Remove node file from network

### DIFF
--- a/include/pops/network.hpp
+++ b/include/pops/network.hpp
@@ -204,8 +204,12 @@ public:
      * network.load(stream);
      * ```
      *
-     * The input network is a list of edges which are pairs of nodes
-     * and the corresponding segments. The input is used as-is. The network is agnostic
+     * The input network is a list of segments where each segment consists of a pairs of
+     * nodes and list of coordinates. In the terminology of the this class, the pair of
+     * nodes is called an edge and the edge with coordinates (or rows and columns) is
+     * called a segment.
+     *
+     * The input is used as-is. The network is agnostic
      * towards how the segments look like in terms of crossing each other or other
      * nodes.
      *

--- a/include/pops/network.hpp
+++ b/include/pops/network.hpp
@@ -158,7 +158,7 @@ public:
     }
 
     /**
-     * @brief Test if a cells is in the bounding box.
+     * @brief Test if a cell is in the bounding box.
      * @param row Row in the raster grid
      * @param col Column in the raster grid
      * @return True if cells is in the bounding box, false otherwise.
@@ -169,9 +169,9 @@ public:
     }
 
     /**
-     * @brief Test if a cells is in the bounding box.
+     * @brief Test if a cell is in the bounding box.
      * @param cell Pair consisting of a row and column indices
-     * @return True if cells is in the bounding box, false otherwise.
+     * @return True if cell is in the bounding box, false otherwise.
      */
     bool cell_out_of_bbox(const std::pair<RasterIndex, RasterIndex>& cell) const
     {
@@ -204,7 +204,7 @@ public:
      * network.load(stream);
      * ```
      *
-     * The input network a list of edges which are pairs of nodes
+     * The input network is a list of edges which are pairs of nodes
      * and the corresponding segments. The input is used as-is. The network is agnostic
      * towards how the segments look like in terms of crossing each other or other
      * nodes.
@@ -586,7 +586,7 @@ protected:
                 if (segment.empty() || segment.back() != new_point)
                     segment.emplace_back(new_point);
             }
-            // If either end nodes of the segment is not in the extent, skip it.
+            // If either node of the segment is not in the extent, skip the segment.
             // This means that a segment is ignored even if one of the nodes and
             // significant portion of the segment is in the area of iterest.
             // TODO: Part of the segment may still be out, so that needs to be checked.

--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -118,14 +118,6 @@ int test_travel_network()
         1,
         1,
     };
-    std::stringstream node_stream{
-        "1,21.4,7.5\n"
-        "2,22.3,7.2\n"
-        "4,22.5,8.6\n"
-        "5,27.5,1.5\n"
-        "8,26.5,6.4\n"
-        "10,28.2,2.7\n"
-        "11,28.3,9.0\n"};
     std::stringstream segment_stream{
         "1,2,21.4;7.5;22.3;7.2\n"
         "1,4,21.4;7.5;21.9;8.0;22.5;8.6\n"
@@ -135,7 +127,7 @@ int test_travel_network()
         "11,8,28.3;9.0;28.5;8.1;28.6;7.3;28.2;6.8;27.7;6.3;27.1;6.4;26.5;6.4\n"
         "2,5,22.3;7.2;23.0;7.7;23.7;8.1;24.3;8.5;25.0;9.0;25.8;9.0;26.6;9.0;27.4;9.0;28.2;9.0;29.0;9.0;29.0;8.0;29.0;7.0;29.0;6.0;29.0;5.0;29.0;4.0;29.0;3.0;29.0;2.0;29.0;1.0;28.2;1.3;27.5;1.5\n"
         "5,8,27.5;1.5;26.7;1.8;26.0;2.0;26.1;2.9;26.2;3.8;26.3;4.7;26.4;5.5;26.5;6.4\n"};
-    network.load(node_stream, segment_stream);
+    network.load(segment_stream);
 
     std::default_random_engine generator;
     const int num_times = 9;
@@ -187,16 +179,10 @@ int test_create_network()
         std::cerr << "Empty network should not have a node at any cell\n";
         ret += 1;
     }
-    std::stringstream node_stream{
-        "1,-79.937,37.270\n"
-        "2,-79.934,37.272\n"
-        "3,-79.902,37.367\n"
-        "4,-79.941,37.273\n"
-        "5,-80.015,37.279\n"};
     std::stringstream segment_stream{
         "1,2,-79.937;37.270;-79.936;37.270;-79.936;37.271;-79.936;37.271;-79.936;37.271;-79.934;37.272;-79.934;37.272\n"
         "3,4,-79.902;37.367;-79.903;37.366;-79.903;37.366;-79.904;37.366;-79.905;37.365;-79.905;37.36;-79.920;37.352;-79.93;37.273;-79.940;37.273;-79.941;37.273\n"};
-    network.load(node_stream, segment_stream);
+    network.load(segment_stream);
     int out_row;
     int out_col;
     std::tie(out_row, out_col) = network.xy_to_row_col(-80.015, 37.279);
@@ -339,10 +325,9 @@ BBox<double> bbox_from_config(const RawConfig& config)
 
 int create_network_from_files(int argc, char** argv)
 {
-    if (argc != 5) {
-        std::cerr
-            << "Usage: " << argv[0]
-            << " read|stats|write|trips|trace CONFIG_FILE NODE_FILE SEGMENT_FILE\n";
+    if (argc != 4) {
+        std::cerr << "Usage: " << argv[0]
+                  << " read|stats|write|trips|trace CONFIG_FILE NETWORK_FILE\n";
         return 1;
     }
     std::string command = argv[1];
@@ -374,16 +359,10 @@ int create_network_from_files(int argc, char** argv)
         std::cerr << "Failed to open config file: " << config_file << "\n";
         return 1;
     }
-    std::string node_file{argv[3]};
-    std::ifstream node_stream{node_file};
-    if (!node_stream.is_open()) {
-        std::cerr << "Failed to open node file: " << node_file << "\n";
-        return 1;
-    }
-    std::string segment_file{argv[4]};
+    std::string segment_file{argv[3]};
     std::ifstream segment_stream{segment_file};
     if (!segment_stream.is_open()) {
-        std::cerr << "Failed to open segment file: " << segment_file << "\n";
+        std::cerr << "Failed to open network segment file: " << segment_file << "\n";
         return 1;
     }
 
@@ -394,7 +373,7 @@ int create_network_from_files(int argc, char** argv)
     double speed = config.get("speed", 0.);
 
     Network<int> network(bbox, nsres, ewres, speed);
-    network.load(node_stream, segment_stream);
+    network.load(segment_stream);
 
     if (show_stats) {
         auto stats = network.collect_statistics();

--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -47,6 +47,63 @@ int compare_network_statistics(
     return ret;
 }
 
+int test_bbox_functions()
+{
+    int ret = 0;
+    BBox<double> bbox;
+    bbox.north = 10;
+    bbox.south = 0;
+    bbox.east = 30;
+    bbox.west = 20;
+    Network<int> network{
+        bbox,
+        1,
+        1,
+        1,
+    };
+    if (network.xy_out_of_bbox(25, 5)) {
+        std::cerr << "XY 25, 5 should be in, not out\n";
+        ++ret;
+    }
+    if (!network.xy_out_of_bbox(25, 11)) {
+        std::cerr << "XY 25, 11 should be out, not in\n";
+        ++ret;
+    }
+    if (network.row_col_out_of_bbox(2, 3)) {
+        std::cerr << "Row 2, col 3 should be in, not out\n";
+        ++ret;
+    }
+    if (!network.row_col_out_of_bbox(20, 3)) {
+        std::cerr << "Row 20, col 3 should be out, not in\n";
+        ++ret;
+    }
+    if (network.cell_out_of_bbox(std::make_pair(9, 8))) {
+        std::cerr << "Cell 9, 8 should be in, not out\n";
+        ++ret;
+    }
+    if (!network.cell_out_of_bbox(std::make_pair(-1, 3))) {
+        std::cerr << "Cell -1, 3 should be out, not in\n";
+        ++ret;
+    }
+    if (network.xy_out_of_bbox(bbox.east, bbox.north)) {
+        std::cerr << "Bbox EN corner XY should be in, not out\n";
+        ++ret;
+    }
+    if (network.xy_out_of_bbox(bbox.west, bbox.south)) {
+        std::cerr << "Bbox WS corner XY should be in, not out\n";
+        ++ret;
+    }
+    if (network.cell_out_of_bbox(network.xy_to_row_col(bbox.east, bbox.north))) {
+        std::cerr << "Bbox EN corner cell should be in, not out\n";
+        ++ret;
+    }
+    if (network.cell_out_of_bbox(network.xy_to_row_col(bbox.west, bbox.south))) {
+        std::cerr << "Bbox WS corner cell should be in, not out\n";
+        ++ret;
+    }
+    return ret;
+}
+
 int test_travel_network()
 {
     int ret = 0;
@@ -439,11 +496,12 @@ int run_tests()
 {
     int ret = 0;
 
+    ret += test_bbox_functions();
     ret += test_create_network();
     ret += test_travel_network();
 
     if (ret)
-        std::cerr << "Number of errors in the network kernel test: " << ret << "\n";
+        std::cerr << "Number of errors in the network test: " << ret << "\n";
     return ret;
 }
 

--- a/tests/test_network_kernel.cpp
+++ b/tests/test_network_kernel.cpp
@@ -100,15 +100,10 @@ int test_model_with_network()
 
     Network<int> network{
         config.bbox, config.ew_res, config.ns_res, config.network_speed};
-    std::stringstream node_stream{
-        "1,16.7,16.7\n"
-        "2,50.0,83.3\n"
-        "3,83.3,83.3\n"
-        "4,83.3,50.0\n"};
     std::stringstream segment_stream{
         "1,2,16.7;16.7;50.0;16.7;50.0;50.0;50.0;83.3\n"
         "4,3,83.3;50.0;83.3;83.3\n"};
-    network.load(node_stream, segment_stream);
+    network.load(segment_stream);
 
     // Objects
     std::vector<std::vector<int>> suitable_cells =


### PR DESCRIPTION
This removes the need to load the network as a file with nodes and another file with segments. Now, only the file with segments is needed since it anyway includes nodes and their coordinates.

There is a slight speed up, but only very small because the node file was small comparing to segments file and the more complex data structures needs to be filled anyway.

However, this simplifies the inputs and required data.
