### PR TITLE
Support more trips in standalone test

### DIFF
--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -372,7 +372,7 @@ int create_network_from_files(int argc, char** argv)
         generator.seed(seed);
         auto nodes = network.get_all_nodes();
         shuffle_container(nodes, generator);
-        int num_nodes = config.get<int>("num_nodes", nodes.size());
+        int num_nodes = config.get<int>("num_start_nodes", nodes.size());
 
         if (trace)
             std::cout << "traces:\n";

--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -378,7 +378,8 @@ int create_network_from_files(int argc, char** argv)
             std::cout << "traces:\n";
         else
             std::cout << "trips:\n";
-        for (const auto& node : nodes) {
+        for (int i = 0; i < num_nodes; ++i) {
+            const auto& node = nodes[i % nodes.size()];
             int start_row = node.second.first;
             int start_col = node.second.second;
             if (!network.has_node_at(start_row, start_col)) {
@@ -428,10 +429,6 @@ int create_network_from_files(int argc, char** argv)
                     std::cout << "    time: " << std::get<2>(cell) << "\n";
                 }
             }
-            // End the loop sooner if are limited by number nodes.
-            --num_nodes;
-            if (!num_nodes)
-                break;
         }
     }
 


### PR DESCRIPTION
- Handle any number of trip start nodes
- Rename num_nodes to num_start_nodes because it is number of nodes from where a trip starts
