### PR TITLE
Rename segment file to network file

### DIFF
--- a/include/pops/network.hpp
+++ b/include/pops/network.hpp
@@ -180,16 +180,16 @@ public:
     }
 
     /**
-     * @brief Load nodes and segments from input streams.
+     * @brief Load network from an input stream.
      *
-     * @param stream Input stream with records for network segments
-     * @param allow_empty True if the loaded network can be empty (no nodes)
+     * @param stream Input stream containing text records for network
+     * @param allow_empty True if the loaded network can be empty
      *
-     * Network segment stream is custom text format resembling CSV geared towards
+     * Network stream is text in a custom format resembling CSV geared towards
      * parsing, not readability, with rows `node_id_1,node_id_2,X1;Y1;X2;Y2;X3;Y3;...`.
-     * Nodes, edges, and segment spatial representation are read from the network
-     * segement stream. Node coordinates are taken from the first and last coordinate
-     * pair in the segment.
+     * Each line represents an edge (pair of connected nodes) and the spatial
+     * representation of the edge (here called a segment). Node coordinates are taken
+     * from the first and last coordinate pair in the segment.
      *
      * The function can take any input stream which behaves like std::ifstream or
      * std::istringstream. These are also the two expected streams to be used
@@ -499,7 +499,7 @@ protected:
     /** Node connections (edges)
      *
      * The matrix is sparse. One node can be connected to multiple nodes.
-     * Connection is both directions is stored explicitly (see load_segments() source
+     * Connection in both directions is stored explicitly (see load_segments() source
      * code).
      */
     using NodeMatrix = std::map<NodeId, std::vector<NodeId>>;
@@ -571,7 +571,7 @@ protected:
             }
             if (node_1_id == node_2_id) {
                 std::runtime_error(
-                    std::string("Segment cannot begin and end with the same node: ")
+                    std::string("Edge cannot begin and end with the same node: ")
                     + node_1_text + " " + node_2_text);
             }
             std::string segment_text;

--- a/tests/test_network.cpp
+++ b/tests/test_network.cpp
@@ -118,7 +118,7 @@ int test_travel_network()
         1,
         1,
     };
-    std::stringstream segment_stream{
+    std::stringstream network_stream{
         "1,2,21.4;7.5;22.3;7.2\n"
         "1,4,21.4;7.5;21.9;8.0;22.5;8.6\n"
         "5,1,27.5;1.5;26.7;1.4;25.9;1.3;25.2;1.1;24.5;1.7;23.9;2.3;23.2;2.8;22.5;2.3;21.8;1.8;21.2;1.3;20.5;1.4;20.7;2.3;20.8;3.2;20.9;4.0;21.0;4.9;21.1;5.7;21.3;6.6;21.4;7.5\n"
@@ -127,7 +127,7 @@ int test_travel_network()
         "11,8,28.3;9.0;28.5;8.1;28.6;7.3;28.2;6.8;27.7;6.3;27.1;6.4;26.5;6.4\n"
         "2,5,22.3;7.2;23.0;7.7;23.7;8.1;24.3;8.5;25.0;9.0;25.8;9.0;26.6;9.0;27.4;9.0;28.2;9.0;29.0;9.0;29.0;8.0;29.0;7.0;29.0;6.0;29.0;5.0;29.0;4.0;29.0;3.0;29.0;2.0;29.0;1.0;28.2;1.3;27.5;1.5\n"
         "5,8,27.5;1.5;26.7;1.8;26.0;2.0;26.1;2.9;26.2;3.8;26.3;4.7;26.4;5.5;26.5;6.4\n"};
-    network.load(segment_stream);
+    network.load(network_stream);
 
     std::default_random_engine generator;
     const int num_times = 9;
@@ -179,10 +179,10 @@ int test_create_network()
         std::cerr << "Empty network should not have a node at any cell\n";
         ret += 1;
     }
-    std::stringstream segment_stream{
+    std::stringstream network_stream{
         "1,2,-79.937;37.270;-79.936;37.270;-79.936;37.271;-79.936;37.271;-79.936;37.271;-79.934;37.272;-79.934;37.272\n"
         "3,4,-79.902;37.367;-79.903;37.366;-79.903;37.366;-79.904;37.366;-79.905;37.365;-79.905;37.36;-79.920;37.352;-79.93;37.273;-79.940;37.273;-79.941;37.273\n"};
-    network.load(segment_stream);
+    network.load(network_stream);
     int out_row;
     int out_col;
     std::tie(out_row, out_col) = network.xy_to_row_col(-80.015, 37.279);
@@ -359,10 +359,10 @@ int create_network_from_files(int argc, char** argv)
         std::cerr << "Failed to open config file: " << config_file << "\n";
         return 1;
     }
-    std::string segment_file{argv[3]};
-    std::ifstream segment_stream{segment_file};
-    if (!segment_stream.is_open()) {
-        std::cerr << "Failed to open network segment file: " << segment_file << "\n";
+    std::string network_file{argv[3]};
+    std::ifstream network_stream{network_file};
+    if (!network_stream.is_open()) {
+        std::cerr << "Failed to open network file: " << network_file << "\n";
         return 1;
     }
 
@@ -373,7 +373,7 @@ int create_network_from_files(int argc, char** argv)
     double speed = config.get("speed", 0.);
 
     Network<int> network(bbox, nsres, ewres, speed);
-    network.load(segment_stream);
+    network.load(network_stream);
 
     if (show_stats) {
         auto stats = network.collect_statistics();

--- a/tests/test_network_kernel.cpp
+++ b/tests/test_network_kernel.cpp
@@ -100,10 +100,10 @@ int test_model_with_network()
 
     Network<int> network{
         config.bbox, config.ew_res, config.ns_res, config.network_speed};
-    std::stringstream segment_stream{
+    std::stringstream network_stream{
         "1,2,16.7;16.7;50.0;16.7;50.0;50.0;50.0;83.3\n"
         "4,3,83.3;50.0;83.3;83.3\n"};
-    network.load(segment_stream);
+    network.load(network_stream);
 
     // Objects
     std::vector<std::vector<int>> suitable_cells =


### PR DESCRIPTION
* Rename (network) segment file to just network file.
* Remove word segment from user-oriented descriptions and interface unless it is specifically referring to the spatial componente or interal object.
