### PR TITLE
Add missing link to changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -422,8 +422,8 @@ and it remains empty until a new change is added.
 - Copy of GDAL code was removed from the repository, using system GDAL
   includes now. (Vaclav Petras)
 
-[unreleased]: https://github.com/ncsu-landscape-dynamics/pops-core/compare/v2.0.0...HEAD
-[1.1.0]: https://github.com/ncsu-landscape-dynamics/pops-core/compare/v1.1.0...v2.0.0
+[Unreleased]: https://github.com/ncsu-landscape-dynamics/pops-core/compare/v2.0.0...HEAD
+[2.0.0]: https://github.com/ncsu-landscape-dynamics/pops-core/compare/v1.1.0...v2.0.0
 [1.1.0]: https://github.com/ncsu-landscape-dynamics/pops-core/compare/v1.0.2...v1.1.0
 [1.0.2]: https://github.com/ncsu-landscape-dynamics/pops-core/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/ncsu-landscape-dynamics/pops-core/compare/v1.0.0...v1.0.1


### PR DESCRIPTION
Fixes copy-paste error in reference to 2.0.0.
