### PR TITLE
Add missing throw statement

### DIFF
--- a/include/pops/network.hpp
+++ b/include/pops/network.hpp
@@ -564,12 +564,12 @@ protected:
             auto node_1_id = node_id_from_text(node_1_text);
             auto node_2_id = node_id_from_text(node_2_text);
             if (node_1_id < 1 || node_2_id < 1) {
-                std::runtime_error(std::string(
+                throw std::runtime_error(std::string(
                     "Node ID must be greater than zero: " + node_1_text + " "
                     + node_2_text));
             }
             if (node_1_id == node_2_id) {
-                std::runtime_error(
+                throw std::runtime_error(
                     std::string("Edge cannot begin and end with the same node: ")
                     + node_1_text + " " + node_2_text);
             }


### PR DESCRIPTION
The throw keyword was missing and the statement had no effect.
