### PR TITLE
Add option to move percentage of exposed/infected hosts to susceptibles

### DIFF
--- a/include/pops/config.hpp
+++ b/include/pops/config.hpp
@@ -54,6 +54,9 @@ public:
     int lethal_temperature_month{0};
     bool weather{false};
     double reproductive_rate{0};
+    // survival rate
+    bool use_survival_rate{false};
+    int survival_rate_month{0};
     // SI/SEI
     std::string model_type;
     int latency_period_steps;
@@ -110,6 +113,9 @@ public:
         if (use_lethal_temperature)
             lethal_schedule_ =
                 scheduler_.schedule_action_yearly(lethal_temperature_month, 1);
+        if (use_survival_rate)
+            survival_rate_schedule_ =
+                scheduler_.schedule_action_yearly(survival_rate_month, 1);
         if (use_spreadrates)
             spread_rate_schedule_ = schedule_from_string(
                 scheduler_, spreadrate_frequency, spreadrate_frequency_n);
@@ -152,6 +158,17 @@ public:
             throw std::logic_error(
                 "Schedules were not created before calling lethal_schedule()");
         return lethal_schedule_;
+    }
+
+    const std::vector<bool>& survival_rate_schedule() const
+    {
+        if (!use_survival_rate)
+            throw std::logic_error(
+                "survival_rate_schedule() not available when use_survival_rate is false");
+        if (!schedules_created_)
+            throw std::logic_error(
+                "Schedules were not created before calling survival_rate_schedule()");
+        return survival_rate_schedule_;
     }
 
     const std::vector<bool>& spread_rate_schedule() const
@@ -201,6 +218,17 @@ public:
             throw std::logic_error(
                 "Schedules were not created before calling num_lethal()");
         return get_number_of_scheduled_actions(lethal_schedule_);
+    }
+
+    unsigned num_survival_rate()
+    {
+        if (!use_survival_rate)
+            throw std::logic_error(
+                "num_survival_rate() not available when use_survival_rate is false");
+        if (!schedules_created_)
+            throw std::logic_error(
+                "Schedules were not created before calling num_survival_rate()");
+        return get_number_of_scheduled_actions(survival_rate_schedule_);
     }
 
     unsigned rate_num_steps()
@@ -302,6 +330,7 @@ private:
     std::vector<bool> output_schedule_;
     std::vector<bool> mortality_schedule_;
     std::vector<bool> lethal_schedule_;
+    std::vector<bool> survival_rate_schedule_;
     std::vector<bool> spread_rate_schedule_;
     std::vector<bool> quarantine_schedule_;
 };

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -189,6 +189,7 @@ public:
         std::vector<IntegerRaster>& mortality_tracker,
         IntegerRaster& died,
         const std::vector<FloatRaster>& temperatures,
+        const std::vector<FloatRaster>& survival_rates,
         const FloatRaster& weather_coefficient,
         Treatments<IntegerRaster, FloatRaster>& treatments,
         IntegerRaster& resistant,
@@ -210,6 +211,18 @@ public:
                 susceptible,
                 temperatures[lethal_step],
                 config_.lethal_temperature,
+                suitable_cells);
+        }
+        // removal of percentage of dispersers
+        if (config_.use_survival_rate && config_.survival_rate_schedule()[step]) {
+            int survival_step =
+                simulation_step_to_action_step(config_.survival_rate_schedule(), step);
+            simulation_.remove_percentage(
+                infected,
+                susceptible,
+                exposed,
+                total_exposed,
+                survival_rates[survival_step],
                 suitable_cells);
         }
         // actual spread

--- a/include/pops/simulation.hpp
+++ b/include/pops/simulation.hpp
@@ -230,13 +230,15 @@ public:
             if (survival_rate(i, j) < 1) {
                 int removed = 0;
                 // remove percentage of infestation/infection in the infected class
-                int removed_infected = infected(i, j) - infected(i, j) * survival_rate(i, j);
+                int removed_infected =
+                    infected(i, j) - infected(i, j) * survival_rate(i, j);
                 infected(i, j) -= removed_infected;
                 removed += removed_infected;
                 // remove the same percentage in each exposed cohort
                 int total_removed_exposed = 0;
                 for (auto& raster : exposed) {
-                    int removed_exposed = raster(i, j) - raster(i, j) * survival_rate(i, j);
+                    int removed_exposed =
+                        raster(i, j) - raster(i, j) * survival_rate(i, j);
                     raster(i, j) -= removed_exposed;
                     total_removed_exposed += removed_exposed;
                     removed += removed_exposed;

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -59,6 +59,7 @@ int test_with_reduced_stochasticity()
     config.model_type = "SI";
     config.latency_period_steps = 0;
     config.use_lethal_temperature = false;
+    config.use_survival_rate = false;
     config.use_quarantine = true;
     config.quarantine_frequency = "year";
     config.quarantine_frequency_n = 1;
@@ -124,6 +125,7 @@ int test_with_reduced_stochasticity()
         empty_integer,
         mortality_tracker,
         died,
+        empty_float,
         empty_float,
         empty_float[0],
         treatments,
@@ -212,6 +214,7 @@ int test_deterministic()
     config.model_type = "SI";
     config.latency_period_steps = 0;
     config.use_lethal_temperature = false;
+    config.use_survival_rate = false;
     config.use_quarantine = false;
     config.use_spreadrates = true;
     config.spreadrate_frequency = "year";
@@ -264,6 +267,7 @@ int test_deterministic()
         empty_integer,
         mortality_tracker,
         died,
+        empty_float,
         empty_float,
         empty_float[0],
         treatments,
@@ -351,6 +355,7 @@ int test_deterministic_exponential()
     config.model_type = "SI";
     config.latency_period_steps = 0;
     config.use_lethal_temperature = false;
+    config.use_survival_rate = false;
     config.use_quarantine = false;
     config.use_spreadrates = true;
     config.spreadrate_frequency = "year";
@@ -404,6 +409,7 @@ int test_deterministic_exponential()
         empty_integer,
         mortality_tracker,
         died,
+        empty_float,
         empty_float,
         empty_float[0],
         treatments,
@@ -487,6 +493,7 @@ int test_model_sei_deterministic()
     config.model_type = "SEI";
     config.latency_period_steps = 11;
     config.use_lethal_temperature = false;
+    config.use_survival_rate = false;
     config.use_quarantine = false;
     config.use_spreadrates = true;
     config.spreadrate_frequency = "year";
@@ -549,6 +556,7 @@ int test_model_sei_deterministic()
             exposed,
             mortality_tracker,
             died,
+            empty_float,
             empty_float,
             empty_float[0],
             treatments,
@@ -627,6 +635,7 @@ int test_model_sei_deterministic_with_treatments()
     config.model_type = "SEI";
     config.latency_period_steps = 11;
     config.use_lethal_temperature = false;
+    config.use_survival_rate = false;
     config.use_quarantine = false;
     config.use_spreadrates = true;
     config.spreadrate_frequency = "year";
@@ -707,6 +716,7 @@ int test_model_sei_deterministic_with_treatments()
             exposed,
             mortality_tracker,
             died,
+            empty_float,
             empty_float,
             empty_float[0],
             treatments,

--- a/tests/test_network_kernel.cpp
+++ b/tests/test_network_kernel.cpp
@@ -128,6 +128,7 @@ int test_model_with_network()
             empty_ints,
             zeros,
             empty_floats,
+            empty_floats,
             empty_floats[0],
             treatments,
             zeros,

--- a/tests/test_overpopulation_movements.cpp
+++ b/tests/test_overpopulation_movements.cpp
@@ -148,6 +148,7 @@ int test_model()
         empty_ints,
         zeros,
         empty_floats,
+        empty_floats,
         empty_floats[0],
         treatments,
         zeros,

--- a/tests/test_simulation_kernels.cpp
+++ b/tests/test_simulation_kernels.cpp
@@ -248,6 +248,7 @@ int test_simulation_with_kernels_generic(
     config.model_type = "SI";
     config.latency_period_steps = 3;
     config.use_lethal_temperature = false;
+    config.use_survival_rate = false;
     config.use_quarantine = false;
     config.use_spreadrates = true;
     config.spreadrate_frequency = "year";
@@ -355,6 +356,7 @@ int test_model_with_kernels_generic(
     config.model_type = "SI";
     config.latency_period_steps = 3;
     config.use_lethal_temperature = false;
+    config.use_survival_rate = false;
     config.use_quarantine = false;
     config.use_spreadrates = true;
     config.spreadrate_frequency = "year";
@@ -431,6 +433,7 @@ int test_model_with_kernels_generic(
             empty_integer,
             mortality_tracker,
             died,
+            empty_float,
             empty_float,
             empty_float[0],
             treatments,


### PR DESCRIPTION
Attempts to address #173. It is written similarly to lethal temperature.

Removes certain percentage of exposed/infected host and makes them susceptible.
The scheduling is done in the same way as lethal temperature, so it is scheduled yearly on the first of certain month.

So far I didn't add any tests and didn't remove lethal temperature. Let me know if this addresses the issue or we want something little different.
