### PR TITLE
Specify file extension in CMake

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,8 +1,12 @@
 name: CMake build and test
 
 on:
-- push
-- pull_request
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
 
 jobs:
   build-ubuntu:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@
 # takes one parameter which is a filename without an extension
 function(add_pops_test NAME)
     # a test is an executable
-    add_executable("${NAME}" "${NAME}")
+    add_executable("${NAME}" "${NAME}.cpp")
 
     # make the PoPS library a dependency
     target_link_libraries(${NAME} pops)


### PR DESCRIPTION
CMake policy CMP0115 now requires explicit extension or setting the policy to the OLD behavior.
