### PR TITLE
Rename deterministic

### DIFF
--- a/include/pops/anthropogenic_kernel.hpp
+++ b/include/pops/anthropogenic_kernel.hpp
@@ -65,7 +65,7 @@ std::unique_ptr<KernelInterface<Generator>> create_anthro_kernel(
         return std::unique_ptr<Kernel>(new Kernel(
             network, config.network_min_distance, config.network_max_distance, jump));
     }
-    else if (config.dispersal_stochasticity) {
+    else if (!config.dispersal_stochasticity) {
         using Kernel = DynamicWrapperKernel<
             DeterministicDispersalKernel<IntegerRaster>,
             Generator>;

--- a/include/pops/anthropogenic_kernel.hpp
+++ b/include/pops/anthropogenic_kernel.hpp
@@ -65,7 +65,7 @@ std::unique_ptr<KernelInterface<Generator>> create_anthro_kernel(
         return std::unique_ptr<Kernel>(new Kernel(
             network, config.network_min_distance, config.network_max_distance, jump));
     }
-    else if (config.deterministic) {
+    else if (config.dispersal_stochasticity) {
         using Kernel = DynamicWrapperKernel<
             DeterministicDispersalKernel<IntegerRaster>,
             Generator>;

--- a/include/pops/config.hpp
+++ b/include/pops/config.hpp
@@ -46,7 +46,7 @@ public:
     bool generate_stochasticity{true};
     bool establishment_stochasticity{true};
     bool movement_stochasticity{true};
-    bool dispersal_stochasticity{false};
+    bool dispersal_stochasticity{true};
     double establishment_probability{0};
     // Temperature
     bool use_lethal_temperature{false};

--- a/include/pops/config.hpp
+++ b/include/pops/config.hpp
@@ -46,7 +46,7 @@ public:
     bool generate_stochasticity{true};
     bool establishment_stochasticity{true};
     bool movement_stochasticity{true};
-    bool deterministic{false};
+    bool dispersal_stochasticity{false};
     double establishment_probability{0};
     // Temperature
     bool use_lethal_temperature{false};

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -97,7 +97,7 @@ protected:
             uniform_kernel,
             network_kernel,
             natural_neighbor_kernel,
-            config_.deterministic);
+            config_.dispersal_stochasticity);
         return selectable_kernel;
     }
 

--- a/include/pops/natural_kernel.hpp
+++ b/include/pops/natural_kernel.hpp
@@ -52,7 +52,7 @@ create_natural_kernel(const Config& config, const IntegerRaster& dispersers)
         return std::unique_ptr<Kernel>(
             new Kernel(direction_from_string(config.natural_direction)));
     }
-    else if (config.dispersal_stochasticity) {
+    else if (!config.dispersal_stochasticity) {
         using Kernel = DynamicWrapperKernel<
             DeterministicDispersalKernel<IntegerRaster>,
             Generator>;

--- a/include/pops/natural_kernel.hpp
+++ b/include/pops/natural_kernel.hpp
@@ -52,7 +52,7 @@ create_natural_kernel(const Config& config, const IntegerRaster& dispersers)
         return std::unique_ptr<Kernel>(
             new Kernel(direction_from_string(config.natural_direction)));
     }
-    else if (config.deterministic) {
+    else if (config.dispersal_stochasticity) {
         using Kernel = DynamicWrapperKernel<
             DeterministicDispersalKernel<IntegerRaster>,
             Generator>;

--- a/include/pops/switch_kernel.hpp
+++ b/include/pops/switch_kernel.hpp
@@ -56,7 +56,7 @@ public:
         const NetworkDispersalKernel<RasterIndex>& network_kernel,
         const DeterministicNeighborDispersalKernel& deterministic_neighbor_kernel =
             DeterministicNeighborDispersalKernel(Direction::None),
-        const bool dispersal_stochasticity = false)
+        const bool dispersal_stochasticity = true)
         : dispersal_kernel_type_(dispersal_kernel_type),
           // Here we initialize all kernels,
           // although we won't use all of them.
@@ -83,7 +83,7 @@ public:
         else if (dispersal_kernel_type_ == DispersalKernelType::Network) {
             return network_kernel_(generator, row, col);
         }
-        else if (dispersal_stochasticity_) {
+        else if (!dispersal_stochasticity_) {
             return deterministic_kernel_(generator, row, col);
         }
         else {
@@ -104,7 +104,7 @@ public:
         else if (dispersal_kernel_type_ == DispersalKernelType::Network) {
             return network_kernel_.is_cell_eligible(row, col);
         }
-        else if (dispersal_stochasticity_) {
+        else if (!dispersal_stochasticity_) {
             return true;
         }
         else {

--- a/include/pops/switch_kernel.hpp
+++ b/include/pops/switch_kernel.hpp
@@ -45,7 +45,7 @@ protected:
     UniformDispersalKernel uniform_kernel_;
     DeterministicNeighborDispersalKernel deterministic_neighbor_kernel_;
     NetworkDispersalKernel<RasterIndex> network_kernel_;
-    bool deterministic_;
+    bool dispersal_stochasticity_;
 
 public:
     SwitchDispersalKernel(
@@ -56,7 +56,7 @@ public:
         const NetworkDispersalKernel<RasterIndex>& network_kernel,
         const DeterministicNeighborDispersalKernel& deterministic_neighbor_kernel =
             DeterministicNeighborDispersalKernel(Direction::None),
-        const bool deterministic = false)
+        const bool dispersal_stochasticity = false)
         : dispersal_kernel_type_(dispersal_kernel_type),
           // Here we initialize all kernels,
           // although we won't use all of them.
@@ -65,7 +65,7 @@ public:
           uniform_kernel_(uniform_kernel),
           deterministic_neighbor_kernel_(deterministic_neighbor_kernel),
           network_kernel_(network_kernel),
-          deterministic_(deterministic)
+          dispersal_stochasticity_(dispersal_stochasticity)
     {}
 
     /*! \copydoc RadialDispersalKernel::operator()()
@@ -83,7 +83,7 @@ public:
         else if (dispersal_kernel_type_ == DispersalKernelType::Network) {
             return network_kernel_(generator, row, col);
         }
-        else if (deterministic_) {
+        else if (dispersal_stochasticity_) {
             return deterministic_kernel_(generator, row, col);
         }
         else {
@@ -104,7 +104,7 @@ public:
         else if (dispersal_kernel_type_ == DispersalKernelType::Network) {
             return network_kernel_.is_cell_eligible(row, col);
         }
-        else if (deterministic_) {
+        else if (dispersal_stochasticity_) {
             return true;
         }
         else {

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -229,7 +229,7 @@ int test_deterministic()
     config.mortality_frequency_n = 1;
     config.create_schedules();
 
-    config.dispersal_stochasticity = true;
+    config.dispersal_stochasticity = false;
 
     unsigned num_mortality_steps = 1;
     std::vector<Raster<int>> mortality_tracker(
@@ -371,7 +371,7 @@ int test_deterministic_exponential()
     config.mortality_frequency_n = 1;
     config.create_schedules();
 
-    config.dispersal_stochasticity = true;
+    config.dispersal_stochasticity = false;
 
     unsigned num_mortality_steps = 1;
     std::vector<Raster<int>> mortality_tracker(
@@ -510,7 +510,7 @@ int test_model_sei_deterministic()
     config.mortality_frequency_n = 1;
     config.create_schedules();
 
-    config.dispersal_stochasticity = true;
+    config.dispersal_stochasticity = false;
 
     std::vector<std::vector<int>> movements;
 
@@ -652,7 +652,7 @@ int test_model_sei_deterministic_with_treatments()
     config.mortality_frequency_n = 1;
     config.create_schedules();
 
-    config.dispersal_stochasticity = true;
+    config.dispersal_stochasticity = false;
 
     std::vector<std::vector<int>> movements;
 

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -229,7 +229,7 @@ int test_deterministic()
     config.mortality_frequency_n = 1;
     config.create_schedules();
 
-    config.deterministic = true;
+    config.dispersal_stochasticity = true;
 
     unsigned num_mortality_steps = 1;
     std::vector<Raster<int>> mortality_tracker(
@@ -371,7 +371,7 @@ int test_deterministic_exponential()
     config.mortality_frequency_n = 1;
     config.create_schedules();
 
-    config.deterministic = true;
+    config.dispersal_stochasticity = true;
 
     unsigned num_mortality_steps = 1;
     std::vector<Raster<int>> mortality_tracker(
@@ -510,7 +510,7 @@ int test_model_sei_deterministic()
     config.mortality_frequency_n = 1;
     config.create_schedules();
 
-    config.deterministic = true;
+    config.dispersal_stochasticity = true;
 
     std::vector<std::vector<int>> movements;
 
@@ -652,7 +652,7 @@ int test_model_sei_deterministic_with_treatments()
     config.mortality_frequency_n = 1;
     config.create_schedules();
 
-    config.deterministic = true;
+    config.dispersal_stochasticity = true;
 
     std::vector<std::vector<int>> movements;
 

--- a/tests/test_simulation_kernels.cpp
+++ b/tests/test_simulation_kernels.cpp
@@ -145,7 +145,7 @@ SwitchDispersalKernel<IntegerRaster, RasterIndex> create_static_natural_kernel(
         uniform_kernel,
         network_kernel,
         natural_neighbor_kernel,
-        config.deterministic);
+        config.dispersal_stochasticity);
     return selectable_kernel;
 }
 /**
@@ -193,7 +193,7 @@ SwitchDispersalKernel<IntegerRaster, RasterIndex> create_static_anthro_kernel(
         uniform_kernel,
         network_kernel,
         anthro_neighbor_kernel,
-        config.deterministic);
+        config.dispersal_stochasticity);
     return selectable_kernel;
 }
 
@@ -264,7 +264,7 @@ int test_simulation_with_kernels_generic(
 
     config.create_schedules();
 
-    config.deterministic = false;
+    config.dispersal_stochasticity = false;
 
     using IntRaster = Raster<int, int>;
     using DoubleRaster = Raster<double, int>;
@@ -375,7 +375,7 @@ int test_model_with_kernels_generic(
 
     config.create_schedules();
 
-    config.deterministic = false;
+    config.dispersal_stochasticity = false;
 
     Raster<int> infected{rows, cols, 10};
     // Susceptible and total are set in a way that there won't be any

--- a/tests/test_simulation_kernels.cpp
+++ b/tests/test_simulation_kernels.cpp
@@ -264,7 +264,7 @@ int test_simulation_with_kernels_generic(
 
     config.create_schedules();
 
-    config.dispersal_stochasticity = false;
+    config.dispersal_stochasticity = true;
 
     using IntRaster = Raster<int, int>;
     using DoubleRaster = Raster<double, int>;
@@ -375,7 +375,7 @@ int test_model_with_kernels_generic(
 
     config.create_schedules();
 
-    config.dispersal_stochasticity = false;
+    config.dispersal_stochasticity = true;
 
     Raster<int> infected{rows, cols, 10};
     // Susceptible and total are set in a way that there won't be any


### PR DESCRIPTION
Changes the name of the deterministic parameter to be dispersal_stochasticity. This makes the naming convention in line with generate_stochasticity, movement_stochasticity, and establishment_stochasticity.