### PR TITLE
quarantine: do not use spatial index when computing bboxes of areas

### DIFF
--- a/include/pops/quarantine.hpp
+++ b/include/pops/quarantine.hpp
@@ -62,38 +62,36 @@ private:
      * Different quarantine areas are represented by different integers.
      * 0 in the raster means no quarantine area.
      */
-    void quarantine_boundary(
-        const IntegerRaster& quarantine_areas,
-        const std::vector<std::vector<int>>& suitable_cells)
+    void quarantine_boundary(const IntegerRaster& quarantine_areas)
     {
         int n, s, e, w;
         int idx = 0;
-        for (auto indices : suitable_cells) {
-            int i = indices[0];
-            int j = indices[1];
-            auto value = quarantine_areas(i, j);
-            if (value > 0) {
-                auto search = boundary_id_idx_map.find(value);
-                int bidx;
-                if (search == boundary_id_idx_map.end()) {
-                    boundary_id_idx_map.insert(std::make_pair(value, idx));
-                    boundaries.push_back(
-                        std::make_tuple(height_ - 1, 0, 0, width_ - 1));
-                    bidx = idx;
-                    ++idx;
+        for (int i = 0; i < height_; i++) {
+            for (int j = 0; j < width_; j++) {
+                auto value = quarantine_areas(i, j);
+                if (value > 0) {
+                    auto search = boundary_id_idx_map.find(value);
+                    int bidx;
+                    if (search == boundary_id_idx_map.end()) {
+                        boundary_id_idx_map.insert(std::make_pair(value, idx));
+                        boundaries.push_back(
+                            std::make_tuple(height_ - 1, 0, 0, width_ - 1));
+                        bidx = idx;
+                        ++idx;
+                    }
+                    else
+                        bidx = search->second;
+                    std::tie(n, s, e, w) = boundaries.at(bidx);
+                    if (i < n)
+                        n = i;
+                    if (i > s)
+                        s = i;
+                    if (j > e)
+                        e = j;
+                    if (j < w)
+                        w = j;
+                    boundaries.at(bidx) = std::make_tuple(n, s, e, w);
                 }
-                else
-                    bidx = search->second;
-                std::tie(n, s, e, w) = boundaries.at(bidx);
-                if (i < n)
-                    n = i;
-                if (i > s)
-                    s = i;
-                if (j > e)
-                    e = j;
-                if (j < w)
-                    w = j;
-                boundaries.at(bidx) = std::make_tuple(n, s, e, w);
             }
         }
     }
@@ -136,8 +134,7 @@ public:
         const IntegerRaster& quarantine_areas,
         double ew_res,
         double ns_res,
-        unsigned num_steps,
-        const std::vector<std::vector<int>>& suitable_cells)
+        unsigned num_steps)
         : width_(quarantine_areas.cols()),
           height_(quarantine_areas.rows()),
           west_east_resolution_(ew_res),
@@ -149,7 +146,7 @@ public:
                   false,
                   std::make_tuple(std::numeric_limits<double>::max(), Direction::None)))
     {
-        quarantine_boundary(quarantine_areas, suitable_cells);
+        quarantine_boundary(quarantine_areas);
     }
 
     QuarantineEscape() = delete;

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -103,7 +103,7 @@ int test_with_reduced_stochasticity()
     SpreadRate<Raster<int>> spread_rate(
         infected, config.ew_res, config.ns_res, rate_num_steps, suitable_cells);
     QuarantineEscape<Raster<int>> quarantine(
-        zeros, config.ew_res, config.ns_res, quarantine_num_steps, suitable_cells);
+        zeros, config.ew_res, config.ns_res, quarantine_num_steps);
 
     auto expected_dispersers = config.reproductive_rate * infected;
     auto expected_established_dispersers = config.reproductive_rate * infected;
@@ -249,8 +249,7 @@ int test_deterministic()
         get_number_of_scheduled_actions(config.spread_rate_schedule());
     SpreadRate<Raster<int>> spread_rate(
         infected, config.ew_res, config.ns_res, rate_num_steps, suitable_cells);
-    QuarantineEscape<Raster<int>> quarantine(
-        zeros, config.ew_res, config.ns_res, 0, suitable_cells);
+    QuarantineEscape<Raster<int>> quarantine(zeros, config.ew_res, config.ns_res, 0);
 
     auto expected_dispersers = config.reproductive_rate * infected;
     auto expected_established_dispersers = config.reproductive_rate * infected;
@@ -401,8 +400,7 @@ int test_deterministic_exponential()
         get_number_of_scheduled_actions(config.spread_rate_schedule());
     SpreadRate<Raster<int>> spread_rate(
         infected, config.ew_res, config.ns_res, rate_num_steps, suitable_cells);
-    QuarantineEscape<Raster<int>> quarantine(
-        zeros, config.ew_res, config.ns_res, 0, suitable_cells);
+    QuarantineEscape<Raster<int>> quarantine(zeros, config.ew_res, config.ns_res, 0);
 
     auto expected_dispersers = config.reproductive_rate * infected;
     auto expected_established_dispersers = config.reproductive_rate * infected;
@@ -554,8 +552,7 @@ int test_model_sei_deterministic()
         get_number_of_scheduled_actions(config.spread_rate_schedule());
     SpreadRate<Raster<int>> spread_rate(
         infected, config.ew_res, config.ns_res, rate_num_steps, suitable_cells);
-    QuarantineEscape<Raster<int>> quarantine(
-        zeros, config.ew_res, config.ns_res, 0, suitable_cells);
+    QuarantineEscape<Raster<int>> quarantine(zeros, config.ew_res, config.ns_res, 0);
 
     // There should be still the original number of infected when dispersers are
     // created.
@@ -702,8 +699,7 @@ int test_model_sei_deterministic_with_treatments()
         get_number_of_scheduled_actions(config.spread_rate_schedule());
     SpreadRate<Raster<int>> spread_rate(
         infected, config.ew_res, config.ns_res, rate_num_steps, suitable_cells);
-    QuarantineEscape<Raster<int>> quarantine(
-        zeros, config.ew_res, config.ns_res, 0, suitable_cells);
+    QuarantineEscape<Raster<int>> quarantine(zeros, config.ew_res, config.ns_res, 0);
 
     // There should be still the original number of infected when dispersers are
     // created.

--- a/tests/test_network_kernel.cpp
+++ b/tests/test_network_kernel.cpp
@@ -109,8 +109,7 @@ int test_model_with_network()
     Treatments<Raster<int>, Raster<double>> treatments(config.scheduler());
     SpreadRate<Raster<int>> spread_rate(
         infected, config.ew_res, config.ns_res, 0, suitable_cells);
-    QuarantineEscape<Raster<int>> quarantine(
-        zeros, config.ew_res, config.ns_res, 0, suitable_cells);
+    QuarantineEscape<Raster<int>> quarantine(zeros, config.ew_res, config.ns_res, 0);
     std::vector<std::vector<int>> movements;
     Model<Raster<int>, Raster<double>, Raster<double>::IndexType> model(config);
     // Run

--- a/tests/test_overpopulation_movements.cpp
+++ b/tests/test_overpopulation_movements.cpp
@@ -131,8 +131,7 @@ int test_model()
     Treatments<Raster<int>, Raster<double>> treatments(config.scheduler());
     SpreadRate<Raster<int>> spread_rate(
         infected, config.ew_res, config.ns_res, 0, suitable_cells);
-    QuarantineEscape<Raster<int>> quarantine(
-        zeros, config.ew_res, config.ns_res, 0, suitable_cells);
+    QuarantineEscape<Raster<int>> quarantine(zeros, config.ew_res, config.ns_res, 0);
     std::vector<std::vector<int>> movements;
     Model<Raster<int>, Raster<double>, Raster<double>::IndexType> model(config);
     // Run

--- a/tests/test_quarantine.cpp
+++ b/tests/test_quarantine.cpp
@@ -91,7 +91,7 @@ int test_quarantine()
         {3, 3}, {3, 4}, {4, 0}, {4, 1}, {4, 2}, {4, 3}, {4, 4}};
 
     std::vector<QuarantineEscape<Raster<int>>> runs(
-        2, QuarantineEscape<Raster<int>>(areas, 10, 10, 3, suitable_cells));
+        2, QuarantineEscape<Raster<int>>(areas, 10, 10, 3));
     runs[0].infection_escape_quarantine(infection11, areas, 0, suitable_cells);
     runs[0].infection_escape_quarantine(infection12, areas, 1, suitable_cells);
     runs[0].infection_escape_quarantine(infection13, areas, 2, suitable_cells);

--- a/tests/test_simulation_kernels.cpp
+++ b/tests/test_simulation_kernels.cpp
@@ -410,8 +410,7 @@ int test_model_with_kernels_generic(
         get_number_of_scheduled_actions(config.spread_rate_schedule());
     SpreadRate<Raster<int>> spread_rate(
         infected, config.ew_res, config.ns_res, rate_num_steps, suitable_cells);
-    QuarantineEscape<Raster<int>> quarantine(
-        zeros, config.ew_res, config.ns_res, 0, suitable_cells);
+    QuarantineEscape<Raster<int>> quarantine(zeros, config.ew_res, config.ns_res, 0);
 
     Model<
         Raster<int>,

--- a/tests/test_soils.cpp
+++ b/tests/test_soils.cpp
@@ -148,8 +148,7 @@ int test_soil_with_model()
         get_number_of_scheduled_actions(config.spread_rate_schedule());
     SpreadRate<Raster<int>> spread_rate(
         infected, config.ew_res, config.ns_res, rate_num_steps, suitable_cells);
-    QuarantineEscape<Raster<int>> quarantine(
-        zeros, config.ew_res, config.ns_res, 0, suitable_cells);
+    QuarantineEscape<Raster<int>> quarantine(zeros, config.ew_res, config.ns_res, 0);
 
     Raster<double> weather = {{1, 0, 0}, {0, 1, 0}, {0, 0, 1}};
 


### PR DESCRIPTION
Fixes #146. No updates to quarantine test were needed since suitable cells cover entire area, so the change does not impact the test result.