### PR TITLE
Define UNUSED, M_PI, PI only conditionally

### DIFF
--- a/include/pops/utils.hpp
+++ b/include/pops/utils.hpp
@@ -16,7 +16,9 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
-#ifndef UNUSED
+#ifdef UNUSED
+#undef UNUSED
+#endif
 /*!
  * Macro to mark unused variables (including parameters) and silence the warning
  * while documenting that it is intentionally unused.
@@ -31,10 +33,10 @@
  *
  * To be replaced by `[[maybe_unused]]` once we migrate to C++17 or higher.
  *
- * We assume that if UNUSED is defined elsewhere, it can be used instead.
+ * We remove any existing UNUSED definition from elsewhere, to ensure we have one
+ * which is compatible with our code.
  */
 #define UNUSED(expr) (void)(expr)
-#endif
 
 // We assume that if the constants are defined elsewhere, they can be used instead.
 #ifndef M_PI

--- a/include/pops/utils.hpp
+++ b/include/pops/utils.hpp
@@ -16,6 +16,7 @@
  * http://www.gnu.org/copyleft/gpl.html
  */
 
+#ifndef UNUSED
 /*!
  * Macro to mark unused variables (including parameters) and silence the warning
  * while documenting that it is intentionally unused.
@@ -29,11 +30,19 @@
  * ```
  *
  * To be replaced by `[[maybe_unused]]` once we migrate to C++17 or higher.
+ *
+ * We assume that if UNUSED is defined elsewhere, it can be used instead.
  */
 #define UNUSED(expr) (void)(expr)
+#endif
 
+// We assume that if the constants are defined elsewhere, they can be used instead.
+#ifndef M_PI
 #define M_PI 3.14159265358979323846
+#endif
+#ifndef PI
 #define PI M_PI
+#endif
 
 #include <algorithm>
 #include <array>


### PR DESCRIPTION
Uses ifndef to detect if the macro was already defined. If defied, it assumes it has the right meaning and uses that instead.

This makes it more compatible with other code which defines these constants. Specifically, new GRASS GIS defines UNUSED, so compiling r.pops.spread then issues a warning or error.