### PR TITLE
Update Ubuntu version for CMake CI

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,8 +16,8 @@ jobs:
     strategy:
       matrix:
         os:
-        - ubuntu-18.04
         - ubuntu-20.04
+        - ubuntu-22.04
         cxx:
         - g++
         - clang++


### PR DESCRIPTION
Ubuntu 18.04 is not supported anymore, 22.04 is available.