### PR TITLE
Quarantine: add option to specify only certain combination of N, S, E, W directions

### DIFF
--- a/include/pops/config.hpp
+++ b/include/pops/config.hpp
@@ -90,6 +90,7 @@ public:
     bool use_quarantine{false};
     std::string quarantine_frequency;
     unsigned quarantine_frequency_n;
+    std::string quarantine_directions;
     // Movements
     bool use_movements{false};
     std::vector<unsigned> movement_schedule;

--- a/tests/test_quarantine.cpp
+++ b/tests/test_quarantine.cpp
@@ -91,7 +91,7 @@ int test_quarantine()
         {3, 3}, {3, 4}, {4, 0}, {4, 1}, {4, 2}, {4, 3}, {4, 4}};
 
     std::vector<QuarantineEscape<Raster<int>>> runs(
-        2, QuarantineEscape<Raster<int>>(areas, 10, 10, 3));
+        2, QuarantineEscape<Raster<int>>(areas, 10, 10, 3, "N,S"));
     runs[0].infection_escape_quarantine(infection11, areas, 0, suitable_cells);
     runs[0].infection_escape_quarantine(infection12, areas, 1, suitable_cells);
     runs[0].infection_escape_quarantine(infection13, areas, 2, suitable_cells);


### PR DESCRIPTION
By default, all directions are used. `QuarantineEscape` has additional parameter `directions`, e.g. `directions = "N,E". Could be useful e.g.,  to ignore spread close to coast.