### PR TITLE
More checks and details in error messages

### DIFF
--- a/include/pops/config.hpp
+++ b/include/pops/config.hpp
@@ -577,6 +577,11 @@ public:
             resulting_row.susceptibility = row[0];
             resulting_row.mortality_rate = row[1];
             resulting_row.mortality_time_lag = row[2];
+            if (resulting_row.susceptibility < 0 || resulting_row.susceptibility > 1) {
+                throw std::invalid_argument(
+                    "Susceptibility needs to be >=0 and <=1, not "
+                    + std::to_string(resulting_row.susceptibility));
+            }
             pest_host_table_data_.push_back(std::move(resulting_row));
         }
     }

--- a/include/pops/config.hpp
+++ b/include/pops/config.hpp
@@ -569,7 +569,9 @@ public:
         for (const auto& row : values) {
             if (row.size() < 3) {
                 throw std::invalid_argument(
-                    "3 values are required for each pest-host table row");
+                    "3 values are required for each pest-host table row "
+                    "(but row size is "
+                    + std::to_string(row.size()) + ")");
             }
             PestHostTableDataRow resulting_row;
             resulting_row.susceptibility = row[0];

--- a/include/pops/host_pool.hpp
+++ b/include/pops/host_pool.hpp
@@ -331,8 +331,10 @@ public:
             throw std::invalid_argument(
                 "Suitability should be >=0 and <=1, not " + std::to_string(suitability)
                 + " (susceptible: " + std::to_string(susceptible_(row, col))
-                + ", total population: " + environment_.total_population_at(row, col)
-                + ", susceptibility: " + pest_host_table_->susceptibility(this) + ")");
+                + ", total population: "
+                + std::to_string(environment_.total_population_at(row, col))
+                + ", susceptibility: "
+                + std::to_string(pest_host_table_->susceptibility(this)) + ")");
         }
         return suitability;
     }

--- a/include/pops/host_pool.hpp
+++ b/include/pops/host_pool.hpp
@@ -326,7 +326,15 @@ public:
         if (pest_host_table_) {
             suitability *= pest_host_table_->susceptibility(this);
         }
-        return environment_.influence_suitability_at(row, col, suitability);
+        suitability = environment_.influence_suitability_at(row, col, suitability);
+        if (suitability < 0 || suitability > 1) {
+            throw std::invalid_argument(
+                "Suitability should be >=0 and <=1, not " + std::to_string(suitability)
+                + " (susceptible: " + std::to_string(susceptible_(row, col))
+                + ", total population: " + environment_.total_population_at(row, col)
+                + ", susceptibility: " + pest_host_table_->susceptibility(this) + ")");
+        }
+        return suitability;
     }
 
     /**

--- a/include/pops/simulation.hpp
+++ b/include/pops/simulation.hpp
@@ -35,10 +35,11 @@ namespace pops {
 
 /*! A class to control the spread simulation.
  *
- * \deprecated
- * The class is deprecated in favor of individual action classes and a higher-level
- * Model. The class corresponding to the original Simulation class before too much code
- * accumulated in Simulation is SpreadAction. The class is now used only in tests.
+ * @note
+ * The class is deprecated for external use in favor of individual action classes and a
+ * higher-level Model. The class corresponding to the original Simulation class before
+ * too much code accumulated in Simulation is SpreadAction. The class is now used only
+ * in tests.
  *
  * The Simulation class handles the mechanics of the model, but the
  * timing of the events or steps should be handled outside of this


### PR DESCRIPTION
* Enforce susceptibility in input pest host table is 0-1
* Enforce that suitability computed by the host pool is 0-1
* Add more details to the size of pest-host table
* Use `@note`, not `@deprecated` for Simulation to avoid need for deprecated attribute (-Wdocumentation-deprecated-sync) which would have to be disabled for tests.