### PR TITLE
Disable the infected-to-dead transition when mortality rate is 0

### DIFF
--- a/include/pops/host_pool.hpp
+++ b/include/pops/host_pool.hpp
@@ -795,6 +795,9 @@ public:
      * individuals is multiplied by the mortality rate to calculate the number of hosts
      * that die that time step.
      *
+     * If mortality rate is zero (<=0), no mortality is applied and mortality tracker
+     * vector stays as is, i.e., no hosts die.
+     *
      * To be used together with step_forward_mortality().
      *
      * @param row Row index of the cell
@@ -805,6 +808,8 @@ public:
     void apply_mortality_at(
         RasterIndex row, RasterIndex col, double mortality_rate, int mortality_time_lag)
     {
+        if (mortality_rate <= 0)
+            return;
         int max_index = mortality_tracker_vector_.size() - mortality_time_lag - 1;
         for (int index = 0; index <= max_index; index++) {
             int mortality_in_index = 0;


### PR DESCRIPTION
A [new test](https://github.com/ncsu-landscape-dynamics/r.pops.spread/pull/70/commits/c8d073ad86ec3fa57e048ce5eee214d33552aa0a) with enabled mortality and mortality rate 0 fails in r.pops.spread CI without this change, but locally passes with this change. The test is set in the way that mortality rate 0 should produce same values as no mortality enabled. Test is for one host only.