### PR TITLE
Replace remove established dispersers by add

### DIFF
--- a/include/pops/actions.hpp
+++ b/include/pops/actions.hpp
@@ -94,12 +94,10 @@ public:
                     soil_pool_->dispersers_to(dispersers_to_soil, i, j, generator);
                     dispersers_from_cell -= dispersers_to_soil;
                 }
-                pests.set_dispersers_at(i, j, dispersers_from_cell);
-                pests.set_established_dispersers_at(i, j, dispersers_from_cell);
+                pests.set_dispersers_at(i, j, dispersers_from_cell, 0);
             }
             else {
-                pests.set_dispersers_at(i, j, 0);
-                pests.set_established_dispersers_at(i, j, 0);
+                pests.set_dispersers_at(i, j, 0, 0);
             }
         }
     }
@@ -123,17 +121,15 @@ public:
             if (pests.dispersers_at(i, j) > 0) {
                 for (int k = 0; k < pests.dispersers_at(i, j); k++) {
                     std::tie(row, col) = dispersal_kernel_(generator, i, j);
-                    // if (row < 0 || row >= rows_ || col < 0 || col >= cols_) {
                     if (host_pool.is_outside(row, col)) {
                         pests.add_outside_disperser_at(row, col);
-                        pests.remove_established_dispersers_at(i, j, 1);
                         continue;
                     }
                     // Put a disperser to the host pool.
                     auto dispersed =
                         host_pool.disperser_to(row, col, generator.establishment());
-                    if (!dispersed) {
-                        pests.remove_established_dispersers_at(i, j, 1);
+                    if (dispersed) {
+                        pests.add_established_dispersers_at(i, j, 1);
                     }
                 }
             }

--- a/include/pops/pest_pool.hpp
+++ b/include/pops/pest_pool.hpp
@@ -53,13 +53,17 @@ public:
     {}
     /**
      * @brief Set number of dispersers
+     *
      * @param row Row number
      * @param col Column number
-     * @param value The new value
+     * @param dispersers Number of dispersers
+     * @param established_dispersers Number of established dispersers
      */
-    void set_dispersers_at(RasterIndex row, RasterIndex col, int value)
+    void set_dispersers_at(
+        RasterIndex row, RasterIndex col, int dispersers, int established_dispersers)
     {
-        dispersers_(row, col) = value;
+        dispersers_(row, col) = dispersers;
+        established_dispersers_(row, col) = established_dispersers;
     }
     /**
      * @brief Return number of dispersers
@@ -82,32 +86,21 @@ public:
     {
         return dispersers_;
     }
+
     /**
-     * @brief Set number of established dispersers
+     * @brief Add established dispersers
      *
-     * Established are dispersers which left cell (row, col) and established themselves
-     * elsewhere, i.e., origin of the established dispersers is tracked.
+     * Established dispersers are dispersers which left cell (row, col) and
+     * established themselves elsewhere, i.e., origin of the established dispersers
+     * is tracked.
      *
      * @param row Row number
      * @param col Column number
-     * @param value The new value
+     * @param count How many dispersers to add
      */
-    void set_established_dispersers_at(RasterIndex row, RasterIndex col, int value)
+    void add_established_dispersers_at(RasterIndex row, RasterIndex col, int count)
     {
-        established_dispersers_(row, col) = value;
-    }
-    // TODO: The following function should not be necessary because pests can't
-    // un-establish. It exists just because it mirrors how the raster was handled in the
-    // original Simulation code.
-    /**
-     * @brief Remove established dispersers
-     * @param row Row number
-     * @param col Column number
-     * @param count How many dispers to remove
-     */
-    void remove_established_dispersers_at(RasterIndex row, RasterIndex col, int count)
-    {
-        established_dispersers_(row, col) -= count;
+        established_dispersers_(row, col) += count;
     }
     /**
      * @brief Add a disperser which left the study area


### PR DESCRIPTION
The initialization of established dispersers now happens together with all dispersers.
The original method which assumed all established and was removing later is replaced by setting to zero and then adding.
