### PR TITLE
Use explicit cast for rounded numbers

### DIFF
--- a/include/pops/actions.hpp
+++ b/include/pops/actions.hpp
@@ -90,7 +90,7 @@ public:
                     // From all the generated dispersers, some go to the soil in the
                     // same cell and don't participate in the kernel-driven dispersal.
                     auto dispersers_to_soil =
-                        std::round(to_soil_percentage_ * dispersers_from_cell);
+                        std::lround(to_soil_percentage_ * dispersers_from_cell);
                     soil_pool_->dispersers_to(dispersers_to_soil, i, j, generator);
                     dispersers_from_cell -= dispersers_to_soil;
                 }
@@ -510,7 +510,7 @@ public:
     void action(Hosts& hosts)
     {
         for (auto indices : hosts.suitable_cells()) {
-            if (action_mortality_) {
+            if (static_cast<bool>(action_mortality_)) {
                 hosts.apply_mortality_at(
                     indices[0], indices[1], mortality_rate_, mortality_time_lag_);
             }

--- a/include/pops/deterministic_kernel.hpp
+++ b/include/pops/deterministic_kernel.hpp
@@ -172,8 +172,10 @@ public:
             // The invalid state is checked later, in this case using the kernel type.
             return;
         }
-        number_of_columns = ceil(max_distance / east_west_resolution) * 2 + 1;
-        number_of_rows = ceil(max_distance / north_south_resolution) * 2 + 1;
+        number_of_columns =
+            static_cast<int>(ceil(max_distance / east_west_resolution)) * 2 + 1;
+        number_of_rows =
+            static_cast<int>(ceil(max_distance / north_south_resolution)) * 2 + 1;
         Raster<double> prob_size(number_of_rows, number_of_columns, 0);
         probability = prob_size;
         probability_copy = prob_size;

--- a/include/pops/network.hpp
+++ b/include/pops/network.hpp
@@ -58,7 +58,7 @@ public:
     /** Get cost of the whole segment (edge). */
     double cost() const
     {
-        if (total_cost_)
+        if (static_cast<bool>(total_cost_))
             return total_cost_;
         // This is short for ((size - 2) + (2 * 1/2)) * cost per cell.
         return (this->size() - 1) * cost_per_cell_;
@@ -72,7 +72,7 @@ public:
     /** Get cost per cell for the segment (edge). */
     double cost_per_cell() const
     {
-        if (total_cost_)
+        if (static_cast<bool>(total_cost_))
             return total_cost_ / (this->size() - 1);
         return cost_per_cell_;
     }

--- a/include/pops/radial_kernel.hpp
+++ b/include/pops/radial_kernel.hpp
@@ -198,8 +198,8 @@ public:
         }
         theta = von_mises(generator);
 
-        row -= round(distance * cos(theta) / north_south_resolution);
-        col += round(distance * sin(theta) / east_west_resolution);
+        row -= lround(distance * cos(theta) / north_south_resolution);
+        col += lround(distance * sin(theta) / east_west_resolution);
 
         return std::make_tuple(row, col);
     }

--- a/include/pops/soils.hpp
+++ b/include/pops/soils.hpp
@@ -90,7 +90,7 @@ public:
             }
         }
         else {
-            dispersers = lambda * count;
+            dispersers = static_cast<int>(std::floor(lambda * count));
         }
         auto draw = draw_n_from_cohorts(*rasters_, dispersers, row, col, generator);
         size_t index = 0;

--- a/include/pops/treatments.hpp
+++ b/include/pops/treatments.hpp
@@ -136,7 +136,7 @@ public:
             return count * this->map_(i, j);
         }
         else if (application == TreatmentApplication::AllInfectedInCell) {
-            return this->map_(i, j) ? count : 0;
+            return static_cast<bool>(this->map_(i, j)) ? count : 0;
         }
         throw std::runtime_error(
             "BaseTreatment::get_treated: unknown TreatmentApplication");

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -698,7 +698,8 @@ int test_model_sei_deterministic_with_treatments()
     // Remove infected
     for (int row = 0; row < expected_infected.rows(); ++row)
         for (int col = 0; col < expected_infected.rows(); ++col)
-            expected_infected(row, col) *= !simple_treatment(row, col);
+            expected_infected(row, col) *=
+                !static_cast<bool>(simple_treatment(row, col));
     // Reduced number of infected
     // (assuming 1 infection (E to I) step completed, i.e. 1 initial state + 1 step)
     for (int row = 0; row < expected_infected.rows(); ++row)


### PR DESCRIPTION
* Replace round by lround to create integer.
* Add static cast to integer for results of existing calls of ceil.
* Explicitly convert to bool using static cast in if-conditions.

These satisfy the -Wfloat-conversion GCC warning for these lines.