### PR TITLE
Provide overloads for Raster operators where ints and floats are mixed

### DIFF
--- a/include/pops/raster.hpp
+++ b/include/pops/raster.hpp
@@ -560,12 +560,13 @@ public:
         return out;
     }
 
-    friend inline Raster pow(Raster image, double value)
+    friend inline Raster pow(const Raster& image, double value)
     {
         image.for_each([value](Number& a) { a = std::pow(a, value); });
         return image;
     }
-    friend inline Raster sqrt(Raster image)
+
+    friend inline Raster sqrt(const Raster& image)
     {
         image.for_each([](Number& a) { a = std::sqrt(a); });
         return image;

--- a/include/pops/raster.hpp
+++ b/include/pops/raster.hpp
@@ -275,7 +275,11 @@ public:
     }
 
     template<typename OtherNumber>
-    Raster& operator+=(OtherNumber value)
+    typename std::enable_if<
+        !(std::is_floating_point<OtherNumber>::value
+          && std::is_integral<Number>::value),
+        Raster&>::type
+    operator+=(OtherNumber value)
     {
         std::for_each(
             data_, data_ + (cols_ * rows_), [&value](Number& a) { a += value; });
@@ -283,7 +287,11 @@ public:
     }
 
     template<typename OtherNumber>
-    Raster& operator-=(OtherNumber value)
+    typename std::enable_if<
+        !(std::is_floating_point<OtherNumber>::value
+          && std::is_integral<Number>::value),
+        Raster&>::type
+    operator-=(OtherNumber value)
     {
         std::for_each(
             data_, data_ + (cols_ * rows_), [&value](Number& a) { a -= value; });
@@ -291,7 +299,11 @@ public:
     }
 
     template<typename OtherNumber>
-    Raster& operator*=(OtherNumber value)
+    typename std::enable_if<
+        !(std::is_floating_point<OtherNumber>::value
+          && std::is_integral<Number>::value),
+        Raster&>::type
+    operator*=(OtherNumber value)
     {
         std::for_each(
             data_, data_ + (cols_ * rows_), [&value](Number& a) { a *= value; });
@@ -299,10 +311,62 @@ public:
     }
 
     template<typename OtherNumber>
-    Raster& operator/=(OtherNumber value)
+    typename std::enable_if<
+        !(std::is_floating_point<OtherNumber>::value
+          && std::is_integral<Number>::value),
+        Raster&>::type
+    operator/=(OtherNumber value)
     {
         std::for_each(
             data_, data_ + (cols_ * rows_), [&value](Number& a) { a /= value; });
+        return *this;
+    }
+
+    template<typename OtherNumber>
+    typename std::enable_if<
+        std::is_floating_point<OtherNumber>::value && std::is_integral<Number>::value,
+        Raster&>::type
+    operator+=(OtherNumber value)
+    {
+        std::for_each(data_, data_ + (cols_ * rows_), [&value](Number& a) {
+            a += static_cast<int>(std::floor(value));
+        });
+        return *this;
+    }
+
+    template<typename OtherNumber>
+    typename std::enable_if<
+        std::is_floating_point<OtherNumber>::value && std::is_integral<Number>::value,
+        Raster&>::type
+    operator-=(OtherNumber value)
+    {
+        std::for_each(data_, data_ + (cols_ * rows_), [&value](Number& a) {
+            a -= static_cast<int>(std::floor(value));
+        });
+        return *this;
+    }
+
+    template<typename OtherNumber>
+    typename std::enable_if<
+        std::is_floating_point<OtherNumber>::value && std::is_integral<Number>::value,
+        Raster&>::type
+    operator*=(OtherNumber value)
+    {
+        std::for_each(data_, data_ + (cols_ * rows_), [&value](Number& a) {
+            a *= static_cast<int>(std::floor(value));
+        });
+        return *this;
+    }
+
+    template<typename OtherNumber>
+    typename std::enable_if<
+        std::is_floating_point<OtherNumber>::value && std::is_integral<Number>::value,
+        Raster&>::type
+    operator/=(OtherNumber value)
+    {
+        std::for_each(data_, data_ + (cols_ * rows_), [&value](Number& a) {
+            a /= static_cast<int>(std::floor(value));
+        });
         return *this;
     }
 

--- a/tests/test_raster.cpp
+++ b/tests/test_raster.cpp
@@ -126,10 +126,22 @@ static int test_multiply_in_place_operator()
     }
 }
 
+static void test_pow()
+{
+    Raster<double> a = {{4, 5}, {2, 3}};
+    Raster<double> b = {{16, 25}, {4, 9}};
+    auto c = pow(a, 2);
+    std::cout << "pow function: ";
+    if (b == c)
+        std::cout << "OK" << std::endl;
+    else
+        std::cout << "\n" << a << "!=\n" << b << std::endl;
+}
+
 static void test_sqrt()
 {
-    Raster<int> a = {{16, 25}, {4, 9}};
-    Raster<int> b = {{4, 5}, {2, 3}};
+    Raster<double> a = {{16, 25}, {4, 9}};
+    Raster<double> b = {{4, 5}, {2, 3}};
     auto c = sqrt(a);
     std::cout << "sqrt function: ";
     if (b == c)
@@ -469,6 +481,7 @@ int main()
     test_plus_operator();
     test_multiply_in_place_operator();
 
+    test_pow();
     test_sqrt();
 
     // all doubles, no problem


### PR DESCRIPTION
Provides a separate set of operator overloads for integral Rasters when the other operand is a floating point number.

We don't support pow and sqrt for ints with -Wfloat-conversion.