### PR TITLE
Add float conversion warning to compile options

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ function(add_pops_test NAME)
     # Enable compiler warnings
     target_compile_options(${NAME} PRIVATE
          $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-              -Wall -Wextra -pedantic -Wfloat-conversion>
+              -Wall -Wextra -pedantic -Wfloat-conversion -Werror>
          $<$<CXX_COMPILER_ID:MSVC>:
               /W4>)
      if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,7 +10,7 @@ function(add_pops_test NAME)
     # Enable compiler warnings
     target_compile_options(${NAME} PRIVATE
          $<$<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>,$<CXX_COMPILER_ID:GNU>>:
-              -Wall -Wextra -pedantic>
+              -Wall -Wextra -pedantic -Wfloat-conversion>
          $<$<CXX_COMPILER_ID:MSVC>:
               /W4>)
      if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")


### PR DESCRIPTION
Fail compilation when a compiler (GCC or Clang) warning is issued. The original motivation is catching -Wfloat-conversion in CI since we invested into fixing it.