### PR TITLE
Allow network node to begin and end edge

### DIFF
--- a/include/pops/network.hpp
+++ b/include/pops/network.hpp
@@ -883,12 +883,6 @@ protected:
                     std::string("Node ID must be greater than zero (node 1, node 2): ")
                     + node_1_text + ", " + node_2_text + ", line: " + line);
             }
-            if (node_1_id == node_2_id) {
-                throw std::runtime_error(
-                    std::string(
-                        "Edge cannot begin and end with the same node (node 1, node 2): ")
-                    + node_1_text + ", " + node_2_text + ", line: " + line);
-            }
             Segment segment;
 
             if (has_probability) {


### PR DESCRIPTION
This removes the check for a network node being the same at the start and end of a segment (edge). This allows for round trips on a segment which visits some cells but returns to the same cell.

This restriction was already lifted for rpops in https://github.com/ncsu-landscape-dynamics/rpops/commit/3e34ad941e82d14c4797a8a094af5e7489fd62ed
