### PR TITLE
Use rounding for overpopulation movements

### DIFF
--- a/include/pops/actions.hpp
+++ b/include/pops/actions.hpp
@@ -365,9 +365,8 @@ public:
                     dispersal_kernel_(generator.overpopulation(), i, j);
                 // for leaving_percentage == 0.5
                 // 2 infected -> 1 leaving
-                // 3 infected -> 1 leaving
-                int leaving =
-                    static_cast<int>(std::floor(original_count * leaving_percentage_));
+                // 3 infected -> 2 leaving (assuming always rounding up for .5)
+                int leaving = std::lround(original_count * leaving_percentage_);
                 leaving = hosts.pests_from(i, j, leaving, generator.overpopulation());
                 if (row < 0 || row >= rows_ || col < 0 || col >= cols_) {
                     pests.add_outside_dispersers_at(row, col, leaving);

--- a/tests/test_overpopulation_movements.cpp
+++ b/tests/test_overpopulation_movements.cpp
@@ -127,8 +127,7 @@ int test_model()
     config.use_spreadrates = false;
     config.create_schedules();
     // More reference data
-    int leaving =
-        static_cast<int>(std::ceil(infected(0, 0) * config.leaving_percentage));
+    int leaving = std::lround(infected(0, 0) * config.leaving_percentage);
     // Objects
     std::vector<std::vector<int>> suitable_cells =
         find_suitable_cells<int>(total_hosts);


### PR DESCRIPTION
This replaces flooring in overpopulation movements by rounding.

It updates the test as well to match (although the original test still passes as is).

- [ ] PR in rpops with this change https://github.com/ncsu-landscape-dynamics/rpops/pull/209
- [x] PR in r.pops.spread with this change https://github.com/ncsu-landscape-dynamics/r.pops.spread/pull/75