### PR TITLE
Use rounding for non-stochastic dispersers from cell

### DIFF
--- a/include/pops/host_pool.hpp
+++ b/include/pops/host_pool.hpp
@@ -307,8 +307,7 @@ public:
             }
         }
         else {
-            dispersers_from_cell =
-                static_cast<int>(std::floor(lambda * infected_at(row, col)));
+            dispersers_from_cell = std::lround(lambda * infected_at(row, col));
         }
         return dispersers_from_cell;
     }


### PR DESCRIPTION
Replaced flooring by rounding in computation of number of dispersers from a cell.

- [x] PR in rpops with this change https://github.com/ncsu-landscape-dynamics/rpops/pull/205
- [x] PR in r.pops.spread with this change https://github.com/ncsu-landscape-dynamics/r.pops.spread/pull/77