### PR TITLE
Explicitly disable mortality in host pool

### DIFF
--- a/include/pops/config.hpp
+++ b/include/pops/config.hpp
@@ -26,6 +26,7 @@
 
 #include "scheduling.hpp"
 #include "utils.hpp"
+#include "model_type.hpp"
 
 #include <cmath>
 #include <vector>
@@ -217,6 +218,12 @@ public:
     double leaving_percentage{0};
     double leaving_scale_coefficient{1};
     double dispersers_to_soils_percentage{0};  ///< Ratio of dispersers going into soil
+
+    /** Get model type as ModelType enum value */
+    ModelType model_type_as_enum() const
+    {
+        return model_type_from_string(model_type);
+    }
 
     void create_schedules()
     {

--- a/include/pops/host_pool.hpp
+++ b/include/pops/host_pool.hpp
@@ -85,10 +85,15 @@ public:
      * host infection over time. Expectation is that mortality tracker is of
      * length (1/mortality_rate + mortality_time_lag).
      *
+     * If *use_mortality* is set to false, the *mortality_tracker_vector* is not
+     * used or otherwise accessed, and any attempts to retrieve mortality information
+     * will provide empty results (but will not fail).
+     *
      * Host is added to the environment by the constructor. Afterwards, the environment
      * is not modified.
      *
      * @param model_type Type of the model (SI or SEI)
+     * @param use_mortality true if morality should be used
      * @param susceptible Raster of susceptible hosts
      * @param exposed Raster of exposed or infected hosts
      * @param latency_period Length of the latency period in steps
@@ -109,6 +114,7 @@ public:
      */
     HostPool(
         ModelType model_type,
+        bool use_mortality,
         IntegerRaster& susceptible,
         std::vector<IntegerRaster>& exposed,
         unsigned latency_period,
@@ -137,12 +143,49 @@ public:
           total_hosts_(total_hosts),
           environment_(environment),
           model_type_(model_type),
+          use_mortality_(use_mortality),
           dispersers_stochasticity_(dispersers_stochasticity),
           reproductive_rate_(reproductive_rate),
           establishment_stochasticity_(establishment_stochasticity),
           deterministic_establishment_probability_(establishment_probability),
           rows_(rows),
           cols_(cols),
+          suitable_cells_(suitable_cells)
+    {
+        environment.add_host(this);
+    }
+
+    /** Constructor overload which takes Config instead of the individual values. */
+    HostPool(
+        const Config& config,
+        IntegerRaster& susceptible,
+        std::vector<IntegerRaster>& exposed,
+        IntegerRaster& infected,
+        IntegerRaster& total_exposed,
+        IntegerRaster& resistant,
+        std::vector<IntegerRaster>& mortality_tracker_vector,
+        IntegerRaster& died,
+        IntegerRaster& total_hosts,
+        Environment& environment,
+        std::vector<std::vector<int>>& suitable_cells)
+        : susceptible_(susceptible),
+          infected_(infected),
+          exposed_(exposed),
+          latency_period_(config.latency_period_steps),
+          total_exposed_(total_exposed),
+          resistant_(resistant),
+          mortality_tracker_vector_(mortality_tracker_vector),
+          died_(died),
+          total_hosts_(total_hosts),
+          environment_(environment),
+          model_type_(config.model_type_as_enum()),
+          use_mortality_(config.use_mortality),
+          dispersers_stochasticity_(config.generate_stochasticity),
+          reproductive_rate_(config.reproductive_rate),
+          establishment_stochasticity_(config.establishment_stochasticity),
+          deterministic_establishment_probability_(config.establishment_probability),
+          rows_(config.rows),
+          cols_(config.cols),
           suitable_cells_(suitable_cells)
     {
         environment.add_host(this);
@@ -266,7 +309,8 @@ public:
         susceptible_(row, col) -= 1;
         if (model_type_ == ModelType::SusceptibleInfected) {
             infected_(row, col) += 1;
-            mortality_tracker_vector_.back()(row, col) += 1;
+            if (use_mortality_)
+                mortality_tracker_vector_.back()(row, col) += 1;
         }
         else if (model_type_ == ModelType::SusceptibleExposedInfected) {
             exposed_.back()(row, col) += 1;
@@ -472,7 +516,7 @@ public:
                 index += 1;
             }
         }
-        if (infected_moved > 0) {
+        if (use_mortality_ && infected_moved > 0) {
             std::vector<int> mortality_draw = draw_n_from_cohorts(
                 mortality_tracker_vector_,
                 infected_moved,
@@ -558,47 +602,49 @@ public:
         // Possibly reuse in the I->S removal.
         if (infected <= 0)
             return;
-        if (mortality_tracker_vector_.size() != mortality.size()) {
-            throw std::invalid_argument(
-                "mortality is not the same size as the internal mortality tracker ("
-                + std::to_string(mortality_tracker_vector_.size())
-                + " != " + std::to_string(mortality.size()) + ") for cell ("
-                + std::to_string(row) + ", " + std::to_string(col) + ")");
-        }
-
-        double mortality_total = 0;
-        for (size_t i = 0; i < mortality.size(); ++i) {
-            if (mortality_tracker_vector_[i](row, col) < mortality[i]) {
+        if (use_mortality_) {
+            if (mortality_tracker_vector_.size() != mortality.size()) {
                 throw std::invalid_argument(
-                    "Mortality value [" + std::to_string(i) + "] is too high ("
-                    + std::to_string(mortality[i]) + " > "
-                    + std::to_string(mortality_tracker_vector_[i](row, col))
-                    + ") for cell (" + std::to_string(row) + ", " + std::to_string(col)
-                    + ")");
+                    "mortality is not the same size as the internal mortality tracker ("
+                    + std::to_string(mortality_tracker_vector_.size())
+                    + " != " + std::to_string(mortality.size()) + ") for cell ("
+                    + std::to_string(row) + ", " + std::to_string(col) + ")");
             }
-            mortality_tracker_vector_[i](row, col) =
-                mortality_tracker_vector_[i](row, col) - mortality[i];
-            mortality_total += mortality[i];
-        }
-        // These two values will only match if we actually compute one from another
-        // and once we don't need to keep the exact same double to int results for
-        // tests. First condition always fails the tests. The second one may potentially
-        // fail.
-        if (false && infected != mortality_total) {
-            throw std::invalid_argument(
-                "Total of removed mortality values differs from removed infected "
-                "count ("
-                + std::to_string(mortality_total) + " != " + std::to_string(infected)
-                + " for cell (" + std::to_string(row) + ", " + std::to_string(col)
-                + ")");
-        }
-        if (false && infected_(row, col) < mortality_total) {
-            throw std::invalid_argument(
-                "Total of removed mortality values is higher than current number "
-                "of infected hosts for cell ("
-                + std::to_string(row) + ", " + std::to_string(col) + ") is too high ("
-                + std::to_string(mortality_total) + " > " + std::to_string(infected)
-                + ")");
+
+            double mortality_total = 0;
+            for (size_t i = 0; i < mortality.size(); ++i) {
+                if (mortality_tracker_vector_[i](row, col) < mortality[i]) {
+                    throw std::invalid_argument(
+                        "Mortality value [" + std::to_string(i) + "] is too high ("
+                        + std::to_string(mortality[i]) + " > "
+                        + std::to_string(mortality_tracker_vector_[i](row, col))
+                        + ") for cell (" + std::to_string(row) + ", "
+                        + std::to_string(col) + ")");
+                }
+                mortality_tracker_vector_[i](row, col) =
+                    mortality_tracker_vector_[i](row, col) - mortality[i];
+                mortality_total += mortality[i];
+            }
+            // These two values will only match if we actually compute one from another
+            // and once we don't need to keep the exact same double to int results for
+            // tests. First condition always fails the tests. The second one may
+            // potentially fail.
+            if (false && infected != mortality_total) {
+                throw std::invalid_argument(
+                    "Total of removed mortality values differs from removed infected "
+                    "count ("
+                    + std::to_string(mortality_total)
+                    + " != " + std::to_string(infected) + " for cell ("
+                    + std::to_string(row) + ", " + std::to_string(col) + ")");
+            }
+            if (false && infected_(row, col) < mortality_total) {
+                throw std::invalid_argument(
+                    "Total of removed mortality values is higher than current number "
+                    "of infected hosts for cell ("
+                    + std::to_string(row) + ", " + std::to_string(col)
+                    + ") is too high (" + std::to_string(mortality_total) + " > "
+                    + std::to_string(infected) + ")");
+            }
         }
         infected_(row, col) -= infected;
         reset_total_host(row, col);
@@ -623,13 +669,15 @@ public:
         // remove percentage of infestation/infection in the infected class
         infected_(row, col) -= count;
         // remove the removed infected from mortality cohorts
-        if (count > 0) {
-            std::vector<int> mortality_draw = draw_n_from_cohorts(
-                mortality_tracker_vector_, count, row, col, generator);
-            int index = 0;
-            for (auto& raster : mortality_tracker_vector_) {
-                raster(row, col) -= mortality_draw[index];
-                index += 1;
+        if (use_mortality_) {
+            if (count > 0) {
+                std::vector<int> mortality_draw = draw_n_from_cohorts(
+                    mortality_tracker_vector_, count, row, col, generator);
+                int index = 0;
+                for (auto& raster : mortality_tracker_vector_) {
+                    raster(row, col) -= mortality_draw[index];
+                    index += 1;
+                }
             }
         }
         // move infested/infected host back to susceptible pool
@@ -748,30 +796,32 @@ public:
             total_resistant += exposed[i];
         }
         infected_(row, col) -= infected;
-        if (mortality_tracker_vector_.size() != mortality.size()) {
-            throw std::invalid_argument(
-                "mortality is not the same size as the internal mortality tracker ("
-                + std::to_string(mortality_tracker_vector_.size())
-                + " != " + std::to_string(mortality.size()) + ") for cell ("
-                + std::to_string(row) + ", " + std::to_string(col) + ")");
-        }
-        int mortality_total = 0;
-        // no simple zip in C++, falling back to indices
-        for (size_t i = 0; i < mortality.size(); ++i) {
-            mortality_tracker_vector_[i](row, col) -= mortality[i];
-            mortality_total += mortality[i];
-        }
-        // These two values will only match if we actually compute one from another
-        // and once we don't need to keep the exact same double to int results for
-        // tests. First condition always fails the tests. The second one may potentially
-        // fail.
-        if (false && infected != mortality_total) {
-            throw std::invalid_argument(
-                "Total of mortality values differs from formerly infected, now resistant "
-                "count ("
-                + std::to_string(mortality_total) + " != " + std::to_string(infected)
-                + " for cell (" + std::to_string(row) + ", " + std::to_string(col)
-                + "))");
+        if (use_mortality_) {
+            if (mortality_tracker_vector_.size() != mortality.size()) {
+                throw std::invalid_argument(
+                    "mortality is not the same size as the internal mortality tracker ("
+                    + std::to_string(mortality_tracker_vector_.size())
+                    + " != " + std::to_string(mortality.size()) + ") for cell ("
+                    + std::to_string(row) + ", " + std::to_string(col) + ")");
+            }
+            int mortality_total = 0;
+            // no simple zip in C++, falling back to indices
+            for (size_t i = 0; i < mortality.size(); ++i) {
+                mortality_tracker_vector_[i](row, col) -= mortality[i];
+                mortality_total += mortality[i];
+            }
+            // These two values will only match if we actually compute one from another
+            // and once we don't need to keep the exact same double to int results for
+            // tests. First condition always fails the tests. The second one may
+            // potentially fail.
+            if (false && infected != mortality_total) {
+                throw std::invalid_argument(
+                    "Total of mortality values differs from formerly infected, now resistant "
+                    "count ("
+                    + std::to_string(mortality_total)
+                    + " != " + std::to_string(infected) + " for cell ("
+                    + std::to_string(row) + ", " + std::to_string(col) + "))");
+            }
         }
         total_resistant += infected;
         resistant_(row, col) += total_resistant;
@@ -814,7 +864,7 @@ public:
     void apply_mortality_at(
         RasterIndex row, RasterIndex col, double mortality_rate, int mortality_time_lag)
     {
-        if (mortality_rate <= 0)
+        if (mortality_rate <= 0 || !use_mortality_)
             return;
         int max_index = mortality_tracker_vector_.size() - mortality_time_lag - 1;
         for (int index = 0; index <= max_index; index++) {
@@ -890,6 +940,8 @@ public:
      */
     void step_forward_mortality()
     {
+        if (!use_mortality_)
+            return;
         rotate_left_by_one(mortality_tracker_vector_);
     }
 
@@ -985,9 +1037,11 @@ public:
     std::vector<int> mortality_by_group_at(RasterIndex row, RasterIndex col) const
     {
         std::vector<int> all;
-        all.reserve(mortality_tracker_vector_.size());
-        for (const auto& raster : mortality_tracker_vector_)
-            all.push_back(raster(row, col));
+        if (use_mortality_) {
+            all.reserve(mortality_tracker_vector_.size());
+            for (const auto& raster : mortality_tracker_vector_)
+                all.push_back(raster(row, col));
+        }
         return all;
     }
 
@@ -1077,7 +1131,8 @@ public:
                 auto& oldest = exposed_.front();
                 // Move hosts to infected raster
                 infected_ += oldest;
-                mortality_tracker_vector_.back() += oldest;
+                if (use_mortality_)
+                    mortality_tracker_vector_.back() += oldest;
                 total_exposed_ += (oldest * (-1));
                 // Reset the raster
                 // (hosts moved from the raster)
@@ -1160,6 +1215,7 @@ private:
     const Environment& environment_;
 
     ModelType model_type_;
+    bool use_mortality_{false};
 
     bool dispersers_stochasticity_{false};
     double reproductive_rate_{0};

--- a/include/pops/model.hpp
+++ b/include/pops/model.hpp
@@ -227,10 +227,9 @@ public:
         std::vector<std::vector<int>>& suitable_cells)
     {
         StandardSingleHostPool host_pool(
-            model_type_from_string(config_.model_type),
+            config_,
             susceptible,
             exposed,
-            config_.latency_period_steps,
             infected,
             total_exposed,
             resistant,
@@ -238,12 +237,6 @@ public:
             died,
             total_hosts,
             environment_,
-            config_.generate_stochasticity,
-            config_.reproductive_rate,
-            config_.establishment_stochasticity,
-            config_.establishment_probability,
-            config_.rows,
-            config_.cols,
             suitable_cells);
         std::vector<StandardSingleHostPool*> host_pools = {&host_pool};
         StandardMultiHostPool multi_host_pool(host_pools, config_);

--- a/include/pops/simulation.hpp
+++ b/include/pops/simulation.hpp
@@ -192,6 +192,7 @@ public:
         IntegerRaster empty;
         StandardHostPool hosts(
             model_type_,
+            bool(mortality_tracker_vector.size()),
             susceptible,
             exposed,
             0,
@@ -245,6 +246,7 @@ public:
         IntegerRaster empty;
         StandardHostPool hosts(
             model_type_,
+            bool(mortality_tracker_vector.size()),
             susceptible,
             exposed,
             0,
@@ -298,6 +300,7 @@ public:
         std::vector<IntegerRaster> empty_vector;
         StandardHostPool hosts{
             model_type_,
+            bool(mortality_tracker_vector.size()),
             empty,
             empty_vector,
             0,
@@ -366,6 +369,7 @@ public:
         IntegerRaster empty;
         StandardHostPool hosts{
             model_type_,
+            bool(mortality_tracker_vector.size()),
             susceptible,
             exposed,
             0,
@@ -413,6 +417,7 @@ public:
         std::vector<IntegerRaster> empty_vector;
         StandardHostPool host_pool{
             model_type_,
+            false,
             empty,
             empty_vector,
             0,
@@ -519,6 +524,7 @@ public:
         IntegerRaster empty;
         StandardHostPool host_pool{
             model_type_,
+            bool(mortality_tracker.size()),
             susceptible,
             exposed,
             0,
@@ -678,6 +684,7 @@ public:
         std::vector<IntegerRaster> empty_vector;
         StandardHostPool hosts{
             model_type_,
+            false,
             susceptible,
             empty_vector,
             0,
@@ -775,6 +782,7 @@ public:
         IntegerRaster empty;
         StandardHostPool host_pool{
             model_type_,
+            bool(mortality_tracker.size()),
             susceptible,
             exposed,
             latency_period_,

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -654,10 +654,9 @@ int test_model_sei_deterministic_with_treatments()
     std::vector<std::vector<int>> movements;
 
     TestModel::StandardSingleHostPool host_pool(
-        model_type_from_string(config.model_type),
+        config,
         susceptible,
         exposed,
-        config.latency_period_steps,
         infected,
         total_exposed,
         resistant,
@@ -665,12 +664,6 @@ int test_model_sei_deterministic_with_treatments()
         died,
         total_hosts,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     std::vector<TestModel::StandardSingleHostPool*> host_pools = {&host_pool};
     TestModel::StandardMultiHostPool multi_host_pool(host_pools, config);

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -71,7 +71,7 @@ int test_with_reduced_stochasticity()
     config.set_date_end(2021, 12, 31);
     config.set_step_unit(StepUnit::Month);
     config.set_step_num_units(1);
-    config.use_mortality = false;
+    config.use_mortality = true;
     config.mortality_frequency = "year";
     config.mortality_frequency_n = 1;
     config.use_treatments = false;
@@ -215,7 +215,7 @@ int test_deterministic()
     config.set_date_end(2021, 12, 31);
     config.set_step_unit(StepUnit::Month);
     config.set_step_num_units(1);
-    config.use_mortality = false;
+    config.use_mortality = true;
     config.mortality_frequency = "year";
     config.mortality_frequency_n = 1;
     config.use_treatments = false;
@@ -356,7 +356,7 @@ int test_deterministic_exponential()
     config.set_date_end(2021, 12, 31);
     config.set_step_unit(StepUnit::Month);
     config.set_step_num_units(1);
-    config.use_mortality = false;
+    config.use_mortality = true;
     config.mortality_frequency = "year";
     config.mortality_frequency_n = 1;
     config.use_treatments = false;

--- a/tests/test_multi_host_model.cpp
+++ b/tests/test_multi_host_model.cpp
@@ -89,10 +89,9 @@ int test_minimal_parameters_one_host()
     Raster<double> weather = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
 
     TestModel::StandardSingleHostPool host_pool(
-        model_type_from_string(config.model_type),
+        config,
         susceptible,
         empty_integers,
-        config.latency_period_steps,
         infected,
         total_exposed,
         empty_integer,
@@ -100,12 +99,6 @@ int test_minimal_parameters_one_host()
         died,
         total_hosts,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     std::vector<TestModel::StandardSingleHostPool*> host_pools = {&host_pool};
     TestModel::StandardMultiHostPool multi_host_pool(host_pools, config);
@@ -267,10 +260,9 @@ int test_minimal_parameters_two_hosts()
     Raster<double> weather = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
 
     TestModel::StandardSingleHostPool host_pool_1(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_1,
         empty_integers,
-        config.latency_period_steps,
         infected_1,
         total_exposed_1,
         empty_integer,
@@ -278,18 +270,11 @@ int test_minimal_parameters_two_hosts()
         died_1,
         total_hosts_1,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     TestModel::StandardSingleHostPool host_pool_2(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_2,
         empty_integers,
-        config.latency_period_steps,
         infected_2,
         total_exposed_2,
         empty_integer,
@@ -297,12 +282,6 @@ int test_minimal_parameters_two_hosts()
         died_2,
         total_hosts_2,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     std::vector<TestModel::StandardSingleHostPool*> host_pools = {
         &host_pool_1, &host_pool_2};
@@ -488,10 +467,9 @@ int test_two_hosts_with_partial_competency_table_one_only()
     Raster<double> weather = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
 
     TestModel::StandardSingleHostPool host_pool_1(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_1,
         empty_integers,
-        config.latency_period_steps,
         infected_1,
         total_exposed_1,
         empty_integer,
@@ -499,18 +477,11 @@ int test_two_hosts_with_partial_competency_table_one_only()
         died_1,
         total_hosts_1,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     TestModel::StandardSingleHostPool host_pool_2(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_2,
         empty_integers,
-        config.latency_period_steps,
         infected_2,
         total_exposed_2,
         empty_integer,
@@ -518,12 +489,6 @@ int test_two_hosts_with_partial_competency_table_one_only()
         died_2,
         total_hosts_2,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     std::vector<TestModel::StandardSingleHostPool*> host_pools = {
         &host_pool_1, &host_pool_2};
@@ -712,10 +677,9 @@ int test_two_hosts_with_complete_competency_table_one_only()
     Raster<double> weather = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
 
     TestModel::StandardSingleHostPool host_pool_1(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_1,
         empty_integers,
-        config.latency_period_steps,
         infected_1,
         total_exposed_1,
         empty_integer,
@@ -723,18 +687,11 @@ int test_two_hosts_with_complete_competency_table_one_only()
         died_1,
         total_hosts_1,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     TestModel::StandardSingleHostPool host_pool_2(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_2,
         empty_integers,
-        config.latency_period_steps,
         infected_2,
         total_exposed_2,
         empty_integer,
@@ -742,12 +699,6 @@ int test_two_hosts_with_complete_competency_table_one_only()
         died_2,
         total_hosts_2,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     std::vector<TestModel::StandardSingleHostPool*> host_pools = {
         &host_pool_1, &host_pool_2};
@@ -941,10 +892,9 @@ int test_two_hosts_with_table_other_than_one()
     Raster<double> weather = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
 
     TestModel::StandardSingleHostPool host_pool_1(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_1,
         empty_integers,
-        config.latency_period_steps,
         infected_1,
         total_exposed_1,
         empty_integer,
@@ -952,18 +902,11 @@ int test_two_hosts_with_table_other_than_one()
         died_1,
         total_hosts_1,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     TestModel::StandardSingleHostPool host_pool_2(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_2,
         empty_integers,
-        config.latency_period_steps,
         infected_2,
         total_exposed_2,
         empty_integer,
@@ -971,12 +914,6 @@ int test_two_hosts_with_table_other_than_one()
         died_2,
         total_hosts_2,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     std::vector<TestModel::StandardSingleHostPool*> host_pools = {
         &host_pool_1, &host_pool_2};
@@ -1168,10 +1105,9 @@ int test_two_hosts_susceptibilities_one()
     Raster<double> weather = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
 
     TestModel::StandardSingleHostPool host_pool_1(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_1,
         empty_integers,
-        config.latency_period_steps,
         infected_1,
         total_exposed_1,
         empty_integer,
@@ -1179,18 +1115,11 @@ int test_two_hosts_susceptibilities_one()
         died_1,
         total_hosts_1,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     TestModel::StandardSingleHostPool host_pool_2(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_2,
         empty_integers,
-        config.latency_period_steps,
         infected_2,
         total_exposed_2,
         empty_integer,
@@ -1198,12 +1127,6 @@ int test_two_hosts_susceptibilities_one()
         died_2,
         total_hosts_2,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     std::vector<TestModel::StandardSingleHostPool*> host_pools = {
         &host_pool_1, &host_pool_2};
@@ -1393,10 +1316,9 @@ int test_two_hosts_susceptibilities_other_than_one()
     Raster<double> weather = {{1, 1, 1}, {1, 1, 1}, {1, 1, 1}};
 
     TestModel::StandardSingleHostPool host_pool_1(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_1,
         empty_integers,
-        config.latency_period_steps,
         infected_1,
         total_exposed_1,
         empty_integer,
@@ -1404,18 +1326,11 @@ int test_two_hosts_susceptibilities_other_than_one()
         died_1,
         total_hosts_1,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     TestModel::StandardSingleHostPool host_pool_2(
-        model_type_from_string(config.model_type),
+        config,
         susceptible_2,
         empty_integers,
-        config.latency_period_steps,
         infected_2,
         total_exposed_2,
         empty_integer,
@@ -1423,12 +1338,6 @@ int test_two_hosts_susceptibilities_other_than_one()
         died_2,
         total_hosts_2,
         model.environment(),
-        config.generate_stochasticity,
-        config.reproductive_rate,
-        config.establishment_stochasticity,
-        config.establishment_probability,
-        config.rows,
-        config.cols,
         suitable_cells);
     std::vector<TestModel::StandardSingleHostPool*> host_pools = {
         &host_pool_1, &host_pool_2};

--- a/tests/test_treatments.cpp
+++ b/tests/test_treatments.cpp
@@ -66,6 +66,7 @@ int test_application_ratio()
 
     StandardSingleHostPool host_pool(
         ModelType::SusceptibleInfected,
+        bool(mortality_tracker.size()),
         susceptible,
         exposed,
         0,
@@ -121,6 +122,7 @@ int test_application_all_inf()
 
     StandardSingleHostPool host_pool(
         ModelType::SusceptibleInfected,
+        bool(mortality_tracker.size()),
         susceptible,
         exposed,
         0,
@@ -178,6 +180,7 @@ int test_application_ratio_pesticide()
 
     StandardSingleHostPool host_pool(
         ModelType::SusceptibleInfected,
+        bool(mortality_tracker.size()),
         susceptible,
         exposed,
         0,
@@ -260,6 +263,7 @@ int test_application_all_inf_pesticide()
 
     StandardSingleHostPool host_pool(
         ModelType::SusceptibleInfected,
+        bool(mortality_tracker.size()),
         susceptible,
         exposed,
         0,
@@ -347,6 +351,7 @@ int test_combination()
 
     StandardSingleHostPool host_pool(
         ModelType::SusceptibleInfected,
+        bool(mortality_tracker.size()),
         susceptible,
         exposed,
         0,
@@ -443,6 +448,7 @@ int test_pesticide_temporal_overlap()
     std::vector<std::vector<int>> suitable_cells = {{0, 0}, {0, 1}, {1, 0}, {1, 1}};
     StandardSingleHostPool host_pool(
         ModelType::SusceptibleInfected,
+        bool(mortality_tracker.size()),
         susceptible,
         exposed,
         0,
@@ -549,6 +555,7 @@ int test_steering()
     std::vector<std::vector<int>> suitable_cells = {{0, 0}, {0, 1}, {1, 0}, {1, 1}};
     StandardSingleHostPool host_pool(
         ModelType::SusceptibleInfected,
+        bool(mortality_tracker.size()),
         susceptible,
         exposed,
         0,
@@ -649,6 +656,7 @@ int test_clear()
     std::vector<std::vector<int>> suitable_cells = {{0, 0}, {0, 1}, {1, 0}, {1, 1}};
     StandardSingleHostPool host_pool(
         ModelType::SusceptibleInfected,
+        bool(mortality_tracker.size()),
         susceptible,
         exposed,
         0,


### PR DESCRIPTION
Instead of relying on size of the mortality vector, ignore the provided data completely when mortality is explicitly disabled. This povides greater flexibility on what rpops and Rcpp can do (#230).

Besides adding yet another config value to the HostPool, add also a constructor which takes a Config object, so that all values can be taken from there. Switch to that in Model and tests when HostPool is used directly, but keep using the old, but updated constructor in tests which don't use config and in Simulation because the Simulation and its tests are not using Config.
