### PR TITLE
Add tests for mortality and time lag

### DIFF
--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -747,6 +747,153 @@ int test_model_sei_deterministic_with_treatments()
     return ret;
 }
 
+/**
+ * Test the model with with mortality
+ */
+int test_deterministic_with_mortality()
+{
+    Raster<int> infected = {{5, 0, 0}, {0, 5, 0}, {0, 0, 2}};
+    Raster<int> susceptible = {{10, 20, 9}, {14, 15, 0}, {3, 0, 2}};
+    Raster<int> total_hosts = susceptible + infected;
+    Raster<int> total_populations = {{20, 20, 20}, {20, 20, 20}, {20, 20, 20}};
+    Raster<int> zeros(infected.rows(), infected.cols(), 0);
+
+    Raster<int> expected_mortality_tracker = {{10, 0, 0}, {0, 10, 0}, {0, 0, 2}};
+    Raster<int> expected_infected = {{15, 0, 0}, {0, 15, 0}, {0, 0, 4}};
+
+    Raster<int> dispersers(infected.rows(), infected.cols());
+    Raster<int> established_dispersers(infected.rows(), infected.cols());
+
+    std::vector<std::tuple<int, int>> outside_dispersers;
+
+    std::vector<std::vector<int>> suitable_cells = {
+        {0, 0}, {0, 1}, {0, 2}, {1, 0}, {1, 1}, {1, 2}, {2, 0}, {2, 1}, {2, 2}};
+
+    Config config;
+    config.weather = false;
+    config.reproductive_rate = 2;
+    config.generate_stochasticity = false;
+    config.establishment_stochasticity = false;
+    config.movement_stochasticity = false;
+    std::vector<std::vector<int>> movements = {
+        {0, 0, 1, 1, 2}, {0, 1, 0, 0, 3}, {0, 1, 1, 0, 2}};
+    config.movement_schedule = {1, 1};
+
+    // We want everything to establish.
+    config.establishment_probability = 1;
+    config.natural_kernel_type = "cauchy";
+    config.natural_direction = "none";
+    config.natural_scale = 0.9;
+    config.anthro_scale = 0.9;
+    config.dispersal_percentage = 0.9;
+    config.natural_kappa = 0;
+    config.anthro_kappa = 0;
+
+    config.use_anthropogenic_kernel = false;
+    config.random_seed = 42;
+    config.rows = infected.rows();
+    config.cols = infected.cols();
+    config.model_type = "SI";
+    config.latency_period_steps = 0;
+    config.use_lethal_temperature = false;
+    config.use_survival_rate = false;
+    config.use_quarantine = false;
+    config.use_spreadrates = false;
+
+    config.set_date_start(2020, 1, 1);
+    config.set_date_end(2021, 12, 31);
+    config.set_step_unit(StepUnit::Month);
+    config.set_step_num_units(1);
+    config.use_mortality = true;
+    config.mortality_frequency = "year";
+    config.mortality_frequency_n = 1;
+    config.use_treatments = false;
+    config.ew_res = 30;
+    config.ns_res = 30;
+    config.create_schedules();
+
+    config.dispersal_stochasticity = false;
+
+    unsigned num_mortality_steps = 1;
+    std::vector<Raster<int>> mortality_tracker(
+        num_mortality_steps, Raster<int>(infected.rows(), infected.cols(), 0));
+
+    Raster<int> died(infected.rows(), infected.cols(), 0);
+    Raster<int> total_exposed(infected.rows(), infected.cols(), 0);
+    std::vector<Raster<int>> empty_integer;
+    std::vector<Raster<double>> empty_floats;
+    QuarantineEscapeAction<Raster<int>> quarantine(
+        zeros, config.ew_res, config.ns_res, 0);
+
+    auto expected_dispersers = config.reproductive_rate * infected;
+    auto expected_established_dispersers = config.reproductive_rate * infected;
+
+    // Limit established dispersers by number of available hosts.
+    for (int row = 0; row < susceptible.rows(); ++row) {
+        for (int col = 0; col < susceptible.cols(); ++col) {
+            if (expected_established_dispersers(row, col) > susceptible(row, col)) {
+                expected_established_dispersers(row, col) = susceptible(row, col);
+            }
+        }
+    }
+
+    int step = 0;
+
+    Model<Raster<int>, Raster<double>, Raster<double>::IndexType> model(config);
+    model.run_step(
+        step++,
+        infected,
+        susceptible,
+        total_populations,
+        total_hosts,
+        dispersers,
+        established_dispersers,
+        total_exposed,
+        empty_integer,
+        mortality_tracker,
+        died,
+        empty_floats,
+        empty_floats,
+        zeros,
+        outside_dispersers,
+        quarantine,
+        zeros,
+        movements,
+        Network<int>::null_network(),
+        suitable_cells);
+
+    if (dispersers != expected_dispersers) {
+        cout << "deterministic: dispersers (actual, expected):\n"
+             << dispersers << "  !=\n"
+             << expected_dispersers << "\n";
+        return 1;
+    }
+    if (established_dispersers != expected_established_dispersers) {
+        cout << "deterministic: established dispersers (actual, expected):\n"
+             << established_dispersers << "  !=\n"
+             << expected_established_dispersers << "\n";
+        return 1;
+    }
+    if (!outside_dispersers.empty()) {
+        cout << "deterministic: There are outside_dispersers ("
+             << outside_dispersers.size() << ") but there should be none\n";
+        return 1;
+    }
+    if (infected != expected_infected) {
+        cout << "deterministic: infected (actual, expected):\n"
+             << infected << "  !=\n"
+             << expected_infected << "\n";
+        return 1;
+    }
+    if (mortality_tracker[0] != expected_mortality_tracker) {
+        cout << "deterministic: mortality tracker (actual, expected):\n"
+             << mortality_tracker[0] << "  !=\n"
+             << expected_mortality_tracker << "\n";
+        return 1;
+    }
+    return 0;
+}
+
 int main()
 {
     int ret = 0;
@@ -756,6 +903,7 @@ int main()
     ret += test_deterministic_exponential();
     ret += test_model_sei_deterministic();
     ret += test_model_sei_deterministic_with_treatments();
+    ret += test_deterministic_with_mortality();
     std::cout << "Test model number of errors: " << ret << std::endl;
 
     return ret;

--- a/tests/test_model.cpp
+++ b/tests/test_model.cpp
@@ -748,7 +748,7 @@ int test_model_sei_deterministic_with_treatments()
 }
 
 /**
- * Test the model with with mortality
+ * Test the model with mortality
  */
 int test_deterministic_with_mortality()
 {

--- a/tests/test_mortality.cpp
+++ b/tests/test_mortality.cpp
@@ -26,6 +26,7 @@
 
 #include <pops/raster.hpp>
 #include <pops/simulation.hpp>
+#include <pops/neighbor_kernel.hpp>
 
 #include <map>
 #include <iostream>
@@ -85,11 +86,230 @@ int test_mortality()
     return 0;
 }
 
+void warn_about_tracker_size(
+    const std::vector<Raster<int>>& mortality_tracker,
+    double mortality_rate,
+    int mortality_time_lag)
+{
+    if (mortality_tracker.size() != 1 / mortality_rate + mortality_time_lag) {
+        cerr << "Non-enforced requirement of mortality tracker vector size "
+                "broken in the mortality time lag test: "
+             << "actual: " << mortality_tracker.size()
+             << ", expected: " << 1 / mortality_rate + mortality_time_lag << "\n";
+    }
+}
+
+int compare_lists_equal(
+    const std::vector<Raster<int>>& reference,
+    const std::vector<Raster<int>>& actual,
+    const std::string& context,
+    int step)
+{
+    int ret = 0;
+    if (reference.size() != actual.size()) {
+        cerr << context << " (step " << step
+             << "): compare_lists_equal: reference and actual differs in size: "
+             << reference.size() << " != " << actual.size() << "\n";
+        ++ret;
+    }
+    for (size_t i = 0; i < std::min(reference.size(), actual.size()); ++i) {
+        if (reference.at(i) != actual.at(i)) {
+            cerr << context << " (step " << step
+                 << "): compare_lists_equal: reference and actual differs at index "
+                 << i << " (max index is " << reference.size() - 1 << "): \n"
+                 << reference.at(i) << " !=\n"
+                 << actual.at(i) << "\n";
+            ++ret;
+        }
+    }
+    return ret;
+}
+
+/**
+ * Test mortality with time lag
+ */
+int test_mortality_lag()
+{
+    int ret = 0;
+
+    Raster<int> infected = {{6, 0}, {0, 0}};
+    Raster<int> total_hosts = {{14, 80}, {6, 4}};
+    Raster<int> died = {{0, 0}, {0, 0}};
+    Raster<int> expected_died = {{0, 0}, {0, 0}};
+    Raster<int> expected_infected = infected;
+    Raster<int> expected_total_hosts = total_hosts;
+    double mortality_rate = 0.50;
+    int mortality_time_lag = 2;
+    std::vector<std::vector<int>> suitable_cells = {{0, 0}, {0, 1}, {1, 0}, {1, 1}};
+
+    Simulation<Raster<int>, Raster<double>> simulation(
+        infected.rows(), infected.cols());
+
+    int step = 1;
+
+    Raster<int> newly_infected = total_hosts - infected;
+    infected += newly_infected;
+    expected_infected += newly_infected;
+    std::vector<Raster<int>> mortality_tracker = {
+        {{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}, newly_infected};
+    warn_about_tracker_size(mortality_tracker, mortality_rate, mortality_time_lag);
+
+    simulation.mortality(
+        infected,
+        total_hosts,
+        mortality_rate,
+        mortality_time_lag,
+        died,
+        mortality_tracker,
+        suitable_cells);
+    ret += compare_lists_equal(
+        {{{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}, newly_infected, {{0, 0}, {0, 0}}},
+        mortality_tracker,
+        "time lag",
+        step);
+    if (died != expected_died) {
+        cout << "time lag: died (actual, expected), step " << step << ":\n"
+             << died << "  !=\n"
+             << expected_died << "\n";
+        ++ret;
+    }
+    if (infected != expected_infected) {
+        cout << "time lag: infected (actual, expected), step " << step << ":\n"
+             << infected << "  !=\n"
+             << expected_infected << "\n";
+        ++ret;
+    }
+    if (total_hosts != expected_total_hosts) {
+        cout << "time lag: total_hosts (actual, expected), step " << step << ":\n"
+             << total_hosts << "  !=\n"
+             << expected_total_hosts << "\n";
+        ++ret;
+    }
+
+    ++step;
+    simulation.mortality(
+        infected,
+        total_hosts,
+        mortality_rate,
+        mortality_time_lag,
+        died,
+        mortality_tracker,
+        suitable_cells);
+    ret += compare_lists_equal(
+        {{{0, 0}, {0, 0}}, newly_infected, {{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}},
+        mortality_tracker,
+        "time lag",
+        step);
+    if (died != expected_died) {
+        cout << "time lag: died (actual, expected), step " << step << ":\n"
+             << died << "  !=\n"
+             << expected_died << "\n";
+        ++ret;
+    }
+    if (infected != expected_infected) {
+        cout << "time lag: infected (actual, expected), step " << step << ":\n"
+             << infected << "  !=\n"
+             << expected_infected << "\n";
+        ++ret;
+    }
+    if (total_hosts != expected_total_hosts) {
+        cout << "time lag: total_hosts (actual, expected), step " << step << ":\n"
+             << total_hosts << "  !=\n"
+             << expected_total_hosts << "\n";
+        ++ret;
+    }
+
+    ++step;
+
+    expected_died = {{8 / 2, 80 / 2}, {6 / 2, 4 / 2}};  // 6 infected are initial state
+    expected_infected -= expected_died;
+    expected_total_hosts -= expected_died;
+    warn_about_tracker_size(mortality_tracker, mortality_rate, mortality_time_lag);
+    simulation.mortality(
+        infected,
+        total_hosts,
+        mortality_rate,
+        mortality_time_lag,
+        died,
+        mortality_tracker,
+        suitable_cells);
+    ret += compare_lists_equal(
+        {newly_infected - expected_died,
+         {{0, 0}, {0, 0}},
+         {{0, 0}, {0, 0}},
+         {{0, 0}, {0, 0}}},
+        mortality_tracker,
+        "time lag",
+        step);
+    if (died != expected_died) {
+        cout << "time lag: died (actual, expected), step " << step << ":\n"
+             << died << "  !=\n"
+             << expected_died << "\n";
+        ++ret;
+    }
+    if (infected != expected_infected) {
+        cout << "time lag: infected (actual, expected), step " << step << ":\n"
+             << infected << "  !=\n"
+             << expected_infected << "\n";
+        ++ret;
+    }
+    if (total_hosts != expected_total_hosts) {
+        cout << "time lag: total_hosts (actual, expected), step " << step << ":\n"
+             << total_hosts << "  !=\n"
+             << expected_total_hosts << "\n";
+        ++ret;
+    }
+
+    // We don't check cumulative died, but died in the step.
+    died.zero();
+
+    ++step;
+
+    // Second half of the infected.
+    expected_died = {{8 / 2, 80 / 2}, {6 / 2, 4 / 2}};
+    expected_infected -= expected_died;
+    expected_total_hosts -= expected_died;
+    warn_about_tracker_size(mortality_tracker, mortality_rate, mortality_time_lag);
+    simulation.mortality(
+        infected,
+        total_hosts,
+        mortality_rate,
+        mortality_time_lag,
+        died,
+        mortality_tracker,
+        suitable_cells);
+    ret += compare_lists_equal(
+        {{{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}, {{0, 0}, {0, 0}}},
+        mortality_tracker,
+        "time lag",
+        step);
+    if (died != expected_died) {
+        cout << "time lag: died (actual, expected), step " << step << ":\n"
+             << died << "  !=\n"
+             << expected_died << "\n";
+        ++ret;
+    }
+    if (infected != expected_infected) {
+        cout << "time lag: infected (actual, expected), step " << step << ":\n"
+             << infected << "  !=\n"
+             << expected_infected << "\n";
+        ++ret;
+    }
+    if (total_hosts != expected_total_hosts) {
+        cout << "time lag: total_hosts (actual, expected), step " << step << ":\n"
+             << total_hosts << "  !=\n"
+             << expected_total_hosts << "\n";
+        ++ret;
+    }
+    return ret;
+}
+
 int main()
 {
     int num_errors = 0;
 
     num_errors += test_mortality();
+    num_errors += test_mortality_lag();
     std::cout << "Mortality number of errors: " << num_errors << std::endl;
     return num_errors;
 }

--- a/tests/test_mortality.cpp
+++ b/tests/test_mortality.cpp
@@ -26,7 +26,6 @@
 
 #include <pops/raster.hpp>
 #include <pops/simulation.hpp>
-#include <pops/neighbor_kernel.hpp>
 
 #include <map>
 #include <iostream>


### PR DESCRIPTION
This tests model with mortality and it tests mortality with time lag in the lightweight Simulation class test.
